### PR TITLE
Preserve cursor marks when saving

### DIFF
--- a/lua/autosave/modules/autocmds.lua
+++ b/lua/autosave/modules/autocmds.lua
@@ -30,7 +30,14 @@ local function actual_save()
     -- might use  update, but in that case it can't be checekd if a file was modified and so it will always
     -- print opts["execution_message"]
     if (api.nvim_eval([[&modified]]) == 1) then
+        local first_char_pos = vim.fn.getpos("'[")
+        local last_char_pos = vim.fn.getpos("']")
+
         cmd("silent! write")
+
+        vim.fn.setpos("'[", first_char_pos)
+        vim.fn.setpos("']", last_char_pos)
+
         if (get_modified() == nil or get_modified() == false) then
             set_modified(true)
         end


### PR DESCRIPTION
When a file is saved in vim, the cursor marks are reset to the beginning and end of the file (see [vim docs](http://vimdoc.sourceforge.net/htmldoc/motion.html#'[)). This can break other plugins or commands that rely on them.

Solution is to capture the marks before the save, and reset them afterwards. This means that (as far as the cursor marks are concerned) nothing was saved.

I've copied the approach and code from here: https://github.com/907th/vim-auto-save/blob/8c1d5dc919030aa712ad7201074ffb60961e9dda/plugin/AutoSave.vim#L74-L80