### PR TITLE
add `filename_is_not` condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
 events = {"InsertLeave", "TextChanged"},
 conditions = {
 	exists = true,
+	filename_is_not = {},
 	filetype_is_not = {},
 	modifiable = true,
 },
@@ -152,6 +153,7 @@ autosave.setup(
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,
+            filename_is_not = {},
             filetype_is_not = {},
             modifiable = true
         },
@@ -181,6 +183,7 @@ autosave.setup(
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,
+            filename_is_not = {},
             filetype_is_not = {},
             modifiable = true
         },
@@ -229,6 +232,7 @@ Although settings already have self-explanatory names, here is where you can fin
 These are the conditions that every file must meet so that it can be saved. If every file to be auto-saved doesn't meet all of the conditions it won't be saved.
 + `exists`: (Boolean) if true, enables this condition. If the file doesn't exist it won't save it (e.g. if you `nvim stuff.txt` and don't save the file then this condition won't be met)
 + `modifiable`: (Boolean) if true, enables this condition. If the file isn't modifiable, then this condition isn't met.
++ `filename_is_not`: (Table, Strings) if there is one or more filenames (should be strings) in the table, it enables this condition. Use this to exclude filenames that you don't want to automatically save.
 + `filetype_is_not`: (Table, Strings) if there is one or more filetypes (should be strings) in the table, it enables this condition. Use this to exclude filetypes that you don't want to automatically save.
 
 ## Hooks

--- a/doc/autosave.txt
+++ b/doc/autosave.txt
@@ -66,6 +66,7 @@ execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
 events = {"InsertLeave", "TextChanged"},
 conditions = {
 	exists = true,
+	filename_is_not = {},
 	filetype_is_not = {},
 	modifiable = true,
 },
@@ -89,6 +90,7 @@ autosave.setup(
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,
+            filename_is_not = {},
             filetype_is_not = {},
             modifiable = true
         },
@@ -113,6 +115,7 @@ autosave.setup(
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,
+            filename_is_not = {},
             filetype_is_not = {},
             modifiable = true
         },
@@ -161,6 +164,7 @@ Although settings already have self-explanatory names, here is where you can fin
 These are the conditions that every file must meet so that it can be saved. If every file to be auto-saved doesn't meet all of the conditions it won't be saved.
 + `exists`: (Boolean) if true, enables this condition. If the file doesn't exist it won't save it (e.g. if you `nvim stuff.txt` and don't save the file then this condition won't be met)
 + `modifiable`: (Boolean) if true, enables this condition. If the file isn't modifiable, then this condition isn't met.
++ `filename_is_not`: (Table, Strings) if there is one or more filenames (should be strings) in the table, it enables this condition. Use this to exclude filenames that you don't want to automatically save.
 + `filetype_is_not`: (Table, Strings) if there is one or more filetypes (should be strings) in the table, it enables this condition. Use this to exclude filetypes that you don't want to automatically save.
 
 ## Hooks

--- a/lua/autosave/config.lua
+++ b/lua/autosave/config.lua
@@ -6,6 +6,7 @@ config.options = {
     events = {"InsertLeave", "TextChanged"},
 	conditions = {
 		exists = true,
+		filename_is_not = {},
 		filetype_is_not = {},
 		modifiable = true,
 	},

--- a/lua/autosave/modules/autocmds.lua
+++ b/lua/autosave/modules/autocmds.lua
@@ -53,7 +53,7 @@ local function actual_save()
 end
 
 local function assert_user_conditions()
-	local sc_exists, sc_filetype, sc_modifiable = true, true, true
+	local sc_exists, sc_filename, sc_filetype, sc_modifiable = true, true, true, true
 
 	for condition, value in pairs(opts["conditions"]) do
 		if condition == "exists" then
@@ -70,6 +70,13 @@ local function assert_user_conditions()
 					break
 				end
 			end
+		elseif condition == "filename_is_not" then
+			if not (next(opts["conditions"]["filename_is_not"]) == nil) then
+				if table_has_value(opts["conditions"]["filename_is_not"], vim.fn.expand('%:t')) == true then
+					sc_filename = false
+					break
+				end
+			end
 		elseif condition == "filetype_is_not" then
 			if not (next(opts["conditions"]["filetype_is_not"]) == nil) then
 				if table_has_value(opts["conditions"]["filetype_is_not"], api.nvim_eval([[&filetype]])) == true then
@@ -80,7 +87,7 @@ local function assert_user_conditions()
 		end
 	end
 
-	return { sc_exists, sc_filetype, sc_modifiable }
+	return { sc_exists, sc_filename, sc_filetype, sc_modifiable }
 end
 
 local function assert_return(values, expected)


### PR DESCRIPTION
## Overview

This is a condition to exclude files by name, useful for files that are automatically loaded on save. (e.g. init.lua, plugins.lua by packer.nvim, etc.)

## Configuration example

```lua
{
  enabled = true,
  execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
  events = {"InsertLeave", "TextChanged"},
  conditions = {
    exists = true,
    filename_is_not = {"init.lua", "plugins.lua"},
    filetype_is_not = {},
    modifiable = true,
  },
  write_all_buffers = false,
  on_off_commands = false,
  clean_command_line_interval = 0,
  debounce_delay = 135
}

```