### PR TITLE
Implement buffer-wise autosaving.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ NeoBundleFetch 'Pocco81/AutoSave.nvim'
 As it's stated in the TL;DR, there are already some sane defaults that you may like, however you can change them to match your taste. These are the defaults:
 ```lua
 enabled = true,
-execution_message = function ()
-  return "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S")
+execution_message = function (buf)
+  return ("AutoSave: saved "
+    .. buf == nil and '*' or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buf), ':t')
+    .. " at " .. vim.fn.strftime("%H:%M:%S"))
 end,
 -- execution_message = "Saved",
 events = {"InsertLeave", "TextChanged"},
@@ -154,7 +156,11 @@ local autosave = require("autosave")
 autosave.setup(
     {
         enabled = true,
-        execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
+        execution_message = function (buf)
+            return ("AutoSave: saved "
+                .. buf == nil and '*' or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buf), ':t')
+                .. " at " .. vim.fn.strftime("%H:%M:%S"))
+        end,
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,
@@ -184,7 +190,11 @@ local autosave = require("autosave")
 autosave.setup(
     {
         enabled = true,
-        execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
+        execution_message = function (buf)
+            return ("AutoSave: saved "
+                .. buf == nil and '*' or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buf), ':t')
+                .. " at " .. vim.fn.strftime("%H:%M:%S"))
+        end,
         events = {"InsertLeave", "TextChanged"},
         conditions = {
             exists = true,

--- a/lua/autosave/config.lua
+++ b/lua/autosave/config.lua
@@ -2,7 +2,11 @@ local config = {}
 
 config.options = {
     enabled = true,
-    execution_message = "AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"),
+    execution_message = function (buf)
+        return ("AutoSave: saved "
+            .. (buf == nil and '*' or vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buf), ':t'))
+            .. " at " .. vim.fn.strftime("%H:%M:%S"))
+    end,
     events = {"InsertLeave", "TextChanged"},
 	conditions = {
 		exists = true,

--- a/lua/autosave/utils/viml_funcs.lua
+++ b/lua/autosave/utils/viml_funcs.lua
@@ -2,8 +2,8 @@ local api = vim.api
 
 api.nvim_exec(
     [[
-	function! g:AutoSaveClearCommandLine(timer)
-		if mode() != 'c'
+	function! g:AutoSaveClearCommandLine(buf, timer)
+		if mode() != 'c' && luaeval("require'autosave.modules.autocmds'.last_notified_buf") == a:buf
 			echon ''
 		endif
 	endfunction


### PR DESCRIPTION
This PR implements buffer-wise autosaving i.e., even if the user switches to a different buffer during `debounce_delay` the originally modified buffer is saved.

Please consider merging it if you find it reasonable.