### PR TITLE
feat: allow to disable execution_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <h2 align="center">🧶 auto-save.nvim</h2>
+	<h2 align="center">🧶 auto-save.nvim</h2>
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ This plugin has been renamed from `AutoSave` to `auto-save`, and this repository
 
 ### 📚 Requirements
 
--   Neovim >= 0.5.0
+- Neovim >= 0.5.0
 
 &nbsp;
 
@@ -86,15 +86,15 @@ EOF
 
 ```lua
 {
-    enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
-    execution_message = {
+	enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
+	execution_message = {
 		message = function() -- message to print on save
 			return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
 		end,
 		dim = 0.18, -- dim the color of `message`
 		cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
 	},
-    trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
+	trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
 	-- function that determines whether to save the current buffer or not
 	-- return true: if buffer is ok to be saved
 	-- return false: if it's not ok to be saved
@@ -109,8 +109,8 @@ EOF
 		end
 		return false -- can't save
 	end,
-    write_all_buffers = false, -- write all buffers when the current one meets `condition`
-    debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+	write_all_buffers = false, -- write all buffers when the current one meets `condition`
+	debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
 	callbacks = { -- functions to be executed at different intervals
 		enabling = nil, -- ran when enabling auto-save
 		disabling = nil, -- ran when disabling auto-save

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ EOF
 {
 	enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
 	execution_message = {
+		enabled = true,
 		message = function() -- message to print on save
 			return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
 		end,

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -2,6 +2,7 @@ Config = {
 	opts = {
 		enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
 		execution_message = {
+			enabled = true,
 			message = function() -- message to print on save
 				return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
 			end,

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -78,7 +78,14 @@ function M.save(buf)
 
 	callback("after_saving")
 
-	api.nvim_echo({ { (type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message), AUTO_SAVE_COLOR } }, true, {})
+	if cnf.opts.execution_message.enabled == true then
+		echo_execution_message()
+	end
+end
+
+local function echo_execution_message()
+	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message
+	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
 	if cnf.opts.execution_message.cleaning_interval > 0 then
 		fn.timer_start(
 			cnf.opts.execution_message.cleaning_interval,


### PR DESCRIPTION
Without this change it is only possible to set `message` to function returning empty string which is still echoed causing previous status message to disappear.
