### PR TITLE
Check if buf is valid in set_buf_var.

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -24,7 +24,9 @@ local function set_buf_var(buf, name, value)
     if buf == nil then
         global_vars[name] = value
     else
-        api.nvim_buf_set_var(buf, 'autosave_' .. name, value)
+        if api.nvim_buf_is_valid(buf) then
+          api.nvim_buf_set_var(buf, 'autosave_' .. name, value)
+        end
     end
 end
 


### PR DESCRIPTION
Since this function is deferred, it is possible that the buffer has already been closed by the time this deferred function is called.
For example, if mapping ESC to close action in Telescope, the telescope buffer is closed immediately after leaving insert mode, before the auto-save event triggered by InsertLeave.