### PR TITLE
Fix callbacks not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ EOF
 	end,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+	print_enabled = true, -- If false, all messages of auto-save.nvim will be disabled.
 	callbacks = { -- functions to be executed at different intervals
 		enabling = nil, -- ran when enabling auto-save
 		disabling = nil, -- ran when disabling auto-save

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -24,6 +24,7 @@ Config = {
 		end,
 		write_all_buffers = false, -- write all buffers when the current one meets `condition`
 		debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+		print_enabled = true, -- If false, all messages of auto-save.nvim will be disabled.
 		callbacks = { -- functions to be executed at different intervals
 			enabling = nil, -- ran when enabling auto-save
 			disabling = nil, -- ran when disabling auto-save

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -82,6 +82,8 @@ function M.save(buf)
 
     callback("after_saving")
 
+    if not cnf.opts.print_enabled then return end
+
     api.nvim_echo(
         {
             {

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -82,22 +82,19 @@ function M.save(buf)
 
     callback("after_saving")
 
-    if not cnf.opts.print_enabled then return end
+    if not cnf.opts.print_enabled then
+        return
+    end
 
-    api.nvim_echo(
+    api.nvim_echo({
         {
-            {
-                (
-                    type(cnf.opts.execution_message.message) == "function"
-                        and cnf.opts.execution_message.message()
-                    or cnf.opts.execution_message.message
-                ),
-                AUTO_SAVE_COLOR,
-            },
+            (
+                type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+                or cnf.opts.execution_message.message
+            ),
+            AUTO_SAVE_COLOR,
         },
-        true,
-        {}
-    )
+    }, true, {})
     if cnf.opts.execution_message.cleaning_interval > 0 then
         fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
             cmd([[echon '']])
@@ -106,8 +103,7 @@ function M.save(buf)
     api.nvim_echo({
         {
             (
-                type(cnf.opts.execution_message.message) == "function"
-                    and cnf.opts.execution_message.message()
+                type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
                 or cnf.opts.execution_message.message
             ),
             AUTO_SAVE_COLOR,
@@ -120,12 +116,13 @@ function M.save(buf)
     end
 end
 
-local save_func = (
-    cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save
-)
+local save_func = nil
 
 local function perform_save()
     g.auto_save_abort = false
+    if save_func == nil then
+        save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
+    end
     save_func()
 end
 
@@ -144,16 +141,14 @@ function M.on()
                 if cnf.opts.execution_message.dim > 0 then
                     MSG_AREA = colors.get_hl("MsgArea")
                     if MSG_AREA.foreground ~= nil then
-                        MSG_AREA.background = (
-                            MSG_AREA.background or colors.get_hl("Normal")["background"]
-                        )
+                        MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
                         local foreground = (
                             o.background == "dark"
-                                and colors.darken(
-                                    (MSG_AREA.background or BLACK),
-                                    cnf.opts.execution_message.dim,
-                                    MSG_AREA.foreground or BLACK
-                                )
+                            and colors.darken(
+                                (MSG_AREA.background or BLACK),
+                                cnf.opts.execution_message.dim,
+                                MSG_AREA.foreground or BLACK
+                            )
                             or colors.lighten(
                                 (MSG_AREA.background or WHITE),
                                 cnf.opts.execution_message.dim,

--- a/lua/auto-save/utils/data.lua
+++ b/lua/auto-save/utils/data.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local cnf = require("auto-save.config").opts
-
 function M.set_of(list)
 	local set = {}
 	for i = 1, #list do
@@ -17,6 +15,8 @@ function M.not_in(var, arr)
 end
 
 function M.do_callback(callback_name)
+	local cnf = require("auto-save.config").opts
+
 	if type(cnf.callbacks[callback_name]) == "function" then
 		cnf.callbacks[callback_name]()
 	end

--- a/lua/auto-save/utils/echo.lua
+++ b/lua/auto-save/utils/echo.lua
@@ -1,6 +1,9 @@
 local TITLE = "auto-save"
 
 return function(msg, kind)
+	local cnf = require("auto-save.config").opts
+	if not cnf.print_enabled then return end
+
 	local has_notify_plugin = pcall(require, "notify")
 	local level = {}
 


### PR DESCRIPTION
The callbacks did not work (because the initial empty configuration was used instead of the user's).

I also added an option to disable vim.notify calls (I want to remove all unnecessary prints and having one after every file change was too much).