### PR TITLE
Add get_autosave_state function

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -192,6 +192,10 @@ function M.toggle()
     end
 end
 
+function M.get_autosave_state()
+	return autosave_running
+end
+
 function M.setup(custom_opts)
     cnf:set_options(custom_opts)
 end

--- a/lua/auto-save/utils/data.lua
+++ b/lua/auto-save/utils/data.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local cnf = require("auto-save.config").opts
-
 function M.set_of(list)
 	local set = {}
 	for i = 1, #list do
@@ -17,6 +15,7 @@ function M.not_in(var, arr)
 end
 
 function M.do_callback(callback_name)
+    local cnf = require("auto-save.config").opts
 	if type(cnf.callbacks[callback_name]) == "function" then
 		cnf.callbacks[callback_name]()
 	end


### PR DESCRIPTION
Restores the original functionality of being able to check whether autosave is enabled or not. Rather than add it as a global, I've just added a getter to retrieve the existing the state in local variable. Closes issue https://github.com/Pocco81/auto-save.nvim/issues/49.