### PR TITLE
Fixes issue where we attempt to access unloaded buffer

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -56,6 +56,10 @@ end
 function M.save(buf)
     buf = buf or api.nvim_get_current_buf()
 
+    if not api.nvim_buf_is_loaded(buf) then
+        return
+    end
+
     callback("before_asserting_save")
 
     if cnf.opts.condition(buf) == false then


### PR DESCRIPTION
I found this issue while trying to get `auto-save.nvim` to work with Harpoon and Telescope but noticed I was getting these errors when I opened and closed Telescope quickly. After further investigation it looks like there is a condition where the plugin tries to save on an unloaded buffer so I added an early return if it is unloaded. The video below illustrates the problem:

https://github.com/pocco81/auto-save.nvim/assets/1207371/c377fd60-545b-4c83-8af7-e87d166cda3c

