### PR TITLE
feat GH 45 add events for enabling and disabling autosave

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,14 +4,13 @@
 
 root = true
 
-
 [*]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = tab
-indent_size = 4
+indent_style = space
+indent_size = 2
 
 [*.txt]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = tabs
+indent_style = tab
 indent_size = 4
 
 [*.txt]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: kdheepak/panvimdoc@v3.0.5
+      - uses: kdheepak/panvimdoc@v3.0.6
         with:
           vimdoc: auto-save.nvim
           version: "Neovim >= 0.8.0"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: kdheepak/panvimdoc@v3
+      - uses: kdheepak/panvimdoc@v3.0.5
         with:
           vimdoc: auto-save.nvim
           version: "Neovim >= 0.8.0"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: kdheepak/panvimdoc@v3
+        with:
+          vimdoc: auto-save.nvim
+          version: "Neovim >= 0.8.0"
+          demojify: true
+          treesitter: true
+          shiftheadinglevelby: -1
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.head_ref }}
+          commit_message: "chore(doc): auto-generate vimdoc"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,16 @@
+name: PR checks
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: JohnnyMorganz/stylua-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check .

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -1,4 +1,3 @@
-name: PR checks
 on:
   pull_request:
     branches:

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -1,7 +1,7 @@
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    paths:
+      - "**.lua"
 
 jobs:
   stylua:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <p align="center">
-	<h2 align="center">🧶 auto-save.nvim</h2>
+  <h2 align="center">🧶 auto-save.nvim</h2>
 </p>
 
 <p align="center">
-	Automatically save your changes in NeoVim
+  Automatically save your changes in NeoVim
 </p>
 
 <p align="center">
-	<a href="https://github.com/okuuva/auto-save.nvim/stargazers">
-		<img alt="Stars" src="https://img.shields.io/github/stars/okuuva/auto-save.nvim?style=for-the-badge&logo=starship&color=C9CBFF&logoColor=D9E0EE&labelColor=302D41"></a>
-	<a href="https://github.com/okuuva/auto-save.nvim/issues">
-		<img alt="Issues" src="https://img.shields.io/github/issues/okuuva/auto-save.nvim?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41"></a>
-	<a href="https://github.com/okuuva/auto-save.nvim">
-		<img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
+  <a href="https://github.com/okuuva/auto-save.nvim/stargazers">
+    <img alt="Stars" src="https://img.shields.io/github/stars/okuuva/auto-save.nvim?style=for-the-badge&logo=starship&color=C9CBFF&logoColor=D9E0EE&labelColor=302D41"></a>
+  <a href="https://github.com/okuuva/auto-save.nvim/issues">
+    <img alt="Issues" src="https://img.shields.io/github/issues/okuuva/auto-save.nvim?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41"></a>
+  <a href="https://github.com/okuuva/auto-save.nvim">
+    <img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
 </p>
 
 &nbsp;
@@ -21,9 +21,9 @@
 
 - automatically save your changes so the world doesn't collapse
 - highly customizable:
-	- conditionals to assert whether to save or not
-	- execution message (it can be dimmed and personalized)
-	- events that trigger auto-save
+  - conditionals to assert whether to save or not
+  - execution message (it can be dimmed and personalized)
+  - events that trigger auto-save
 - debounce the save with a delay
 - multiple callbacks
 - automatically clean the message area
@@ -41,49 +41,49 @@
 Install the plugin with your favourite package manager:
 
 <details>
-	<summary><a href="https://github.com/folke/lazy.nvim">Lazy.nvim</a></summary>
+  <summary><a href="https://github.com/folke/lazy.nvim">Lazy.nvim</a></summary>
 
 ```lua
 {
-	"okuuva/auto-save.nvim",
-	cmd = "ASToggle", -- optional for lazy loading on command
-	event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
-	opts = {
-		-- your config goes here
-		-- or just leave it empty :)
-	},
+  "okuuva/auto-save.nvim",
+  cmd = "ASToggle", -- optional for lazy loading on command
+  event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
+  opts = {
+    -- your config goes here
+    -- or just leave it empty :)
+  },
 },
 ```
 
 </details>
 
 <details>
-	<summary><a href="https://github.com/wbthomason/packer.nvim">Packer.nvim</a></summary>
+  <summary><a href="https://github.com/wbthomason/packer.nvim">Packer.nvim</a></summary>
 
 ```lua
 use({
-	"okuuva/auto-save.nvim",
-	config = function()
-		 require("auto-save").setup {
-			-- your config goes here
-			-- or just leave it empty :)
-		 }
-	end,
+  "okuuva/auto-save.nvim",
+  config = function()
+   require("auto-save").setup {
+     -- your config goes here
+     -- or just leave it empty :)
+   }
+  end,
 })
 ```
 
 </details>
 
 <details>
-	<summary><a href="https://github.com/junegunn/vim-plug">vim-plug</a></summary>
+  <summary><a href="https://github.com/junegunn/vim-plug">vim-plug</a></summary>
 
 ```vim
 Plug 'okuuva/auto-save.nvim'
 lua << EOF
-	require("auto-save").setup {
-		-- your config goes here
-		-- or just leave it empty :)
-	}
+  require("auto-save").setup {
+    -- your config goes here
+    -- or just leave it empty :)
+  }
 EOF
 ```
 
@@ -97,39 +97,39 @@ EOF
 
 ```lua
 {
-	enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
-	execution_message = {
-		enabled = true,
-		message = function() -- message to print on save
-			return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
-		end,
-		dim = 0.18, -- dim the color of `message`
-		cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
-	},
-	trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
-	-- function that determines whether to save the current buffer or not
-	-- return true: if buffer is ok to be saved
-	-- return false: if it's not ok to be saved
-	condition = function(buf)
-		local fn = vim.fn
-		local utils = require("auto-save.utils.data")
+  enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
+  execution_message = {
+    enabled = true,
+    message = function() -- message to print on save
+      return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
+    end,
+    dim = 0.18, -- dim the color of `message`
+    cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
+  },
+  trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
+  -- function that determines whether to save the current buffer or not
+  -- return true: if buffer is ok to be saved
+  -- return false: if it's not ok to be saved
+  condition = function(buf)
+    local fn = vim.fn
+    local utils = require("auto-save.utils.data")
 
-		if
-			fn.getbufvar(buf, "&modifiable") == 1 and
-			utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
-			return true -- met condition(s), can save
-		end
-		return false -- can't save
-	end,
-	write_all_buffers = false, -- write all buffers when the current one meets `condition`
-	debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
-	callbacks = { -- functions to be executed at different intervals
-		enabling = nil, -- ran when enabling auto-save
-		disabling = nil, -- ran when disabling auto-save
-		before_asserting_save = nil, -- ran before checking `condition`
-		before_saving = nil, -- ran before doing the actual save
-		after_saving = nil -- ran after doing the actual save
-	}
+    if
+      fn.getbufvar(buf, "&modifiable") == 1 and
+      utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
+      return true -- met condition(s), can save
+    end
+    return false -- can't save
+  end,
+  write_all_buffers = false, -- write all buffers when the current one meets `condition`
+  debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+  callbacks = { -- functions to be executed at different intervals
+    enabling = nil, -- ran when enabling auto-save
+    disabling = nil, -- ran when disabling auto-save
+    before_asserting_save = nil, -- ran before checking `condition`
+    before_saving = nil, -- ran before doing the actual save
+    after_saving = nil -- ran after doing the actual save
+  }
 }
 ```
 
@@ -143,11 +143,11 @@ or as part of the `lazy.nvim` plugin spec:
 
 ```lua
 {
-	"okuuva/auto-save.nvim",
-	keys = {
-		{ "<leader>n", ":ASToggle<CR>", desc = "Toggle auto-save" },
-	},
-	...
+  "okuuva/auto-save.nvim",
+  keys = {
+    { "<leader>n", ":ASToggle<CR>", desc = "Toggle auto-save" },
+  },
+  ...
 },
 
 ```

--- a/README.md
+++ b/README.md
@@ -111,11 +111,10 @@ EOF
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
   debounce_delay = 1000, -- delay after which a pending save is executed
   callbacks = { -- functions to be executed at different intervals
-    enabling = nil, -- ran when enabling auto-save
-    disabling = nil, -- ran when disabling auto-save
     before_saving = nil, -- ran before doing the actual save
-    after_saving = nil -- ran after doing the actual save
-  }
+  },
+ -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
+  debug = false,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   - execution message (it can be dimmed and personalized)
   - events that trigger auto-save
 - debounce the save with a delay
-- multiple callbacks
+- hook into the lifecycle with autocommands
 - automatically clean the message area
 
 ## 📚 Requirements
@@ -113,9 +113,6 @@ EOF
   condition = nil,
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
   debounce_delay = 1000, -- delay after which a pending save is executed
-  callbacks = { -- functions to be executed at different intervals
-    before_saving = nil, -- ran before doing the actual save
-  },
  -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
   debug = false,
 }
@@ -184,6 +181,34 @@ or as part of the `lazy.nvim` plugin spec:
 },
 
 ```
+
+## 🪝 Events / Callbacks
+
+The plugin fires events at various points during its lifecycle which users can hook into:
+
+- `AutoSaveWritePre` Just before a buffer is getting saved
+- `AutoSaveWritePost` Just after a buffer is getting saved
+
+It will always supply the current buffer in the `data.saved_buffer`
+
+An example to always print the file name before a file is getting saved (use `:messages` if the execution message swallows the print):
+
+```lua
+local group = vim.api.nvim_create_augroup('autosave', {})
+
+vim.api.nvim_create_autocmd('User', {
+    pattern = 'AutoSaveWritePre',
+    group = group,
+    callback = function(opts)
+        if opts.data.saved_buffer ~= nil then
+            local filename = vim.api.nvim_buf_get_name(opts.data.saved_buffer)
+            print('We are about to save ' .. filename .. ' get ready captain!')
+        end
+    end,
+})
+```
+
+If you want more Events, feel free to open an issue.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Besides running auto-save at startup (if you have `enabled = true` in your confi
 
 &nbsp;
 
+### 🤝 Contributing
+
+- All pull requests are welcome.
+- If you encounter bugs please open an issue.
+
 ### 👋 Acknowledgements
 
 This plugin wouldn't exist without [Pocco81](https://github.com/Pocco81)'s work on the [original](https://github.com/Pocco81/auto-save.nvim).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ or as part of the `lazy.nvim` plugin spec:
 
 ```
 
-## 🪝 Events / Callbacks
+## ↩️  Events / Callbacks
 
 The plugin fires events at various points during its lifecycle which users can hook into:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the plugin with your favourite package manager:
 {
   "okuuva/auto-save.nvim",
   cmd = "ASToggle", -- optional for lazy loading on command
-  event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
+  event = { "InsertLeave", "TextChanged" }, -- optional for lazy loading on trigger events
   opts = {
     -- your config goes here
     -- or just leave it empty :)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@
 
 &nbsp;
 
-### 📢 Disclaimer: Breaking Change
-
-This plugin has been renamed from `AutoSave` to `auto-save`, and this repository has accordingly moved from `pocco81/AutoSave.nvim` to `pocco81/auto-save.nvim`. To prevent errors with your configuration, make sure to update both the name and the repository url in your config! 
-
-&nbsp;
-
 ### 📋 Features
 
 - automatically save your changes so the world doesn't collapse

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ EOF
   -- if set to `nil` then no specific condition is applied
   condition = nil,
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
+  noautocmd = false, -- do not execute autocmds when saving
   debounce_delay = 1000, -- delay after which a pending save is executed
  -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
   debug = false,

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 </p>
 
 <p align="center">
-	<a href="https://github.com/Pocco81/auto-save.nvim/stargazers">
-		<img alt="Stars" src="https://img.shields.io/github/stars/Pocco81/auto-save.nvim?style=for-the-badge&logo=starship&color=C9CBFF&logoColor=D9E0EE&labelColor=302D41"></a>
-	<a href="https://github.com/Pocco81/auto-save.nvim/issues">
-		<img alt="Issues" src="https://img.shields.io/github/issues/Pocco81/auto-save.nvim?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41"></a>
-	<a href="https://github.com/Pocco81/auto-save.nvim">
-		<img alt="Repo Size" src="https://img.shields.io/github/repo-size/Pocco81/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
+	<a href="https://github.com/okuuva/auto-save.nvim/stargazers">
+		<img alt="Stars" src="https://img.shields.io/github/stars/okuuva/auto-save.nvim?style=for-the-badge&logo=starship&color=C9CBFF&logoColor=D9E0EE&labelColor=302D41"></a>
+	<a href="https://github.com/okuuva/auto-save.nvim/issues">
+		<img alt="Issues" src="https://img.shields.io/github/issues/okuuva/auto-save.nvim?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41"></a>
+	<a href="https://github.com/okuuva/auto-save.nvim">
+		<img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
 </p>
 
 &nbsp;
@@ -45,7 +45,7 @@ Install the plugin with your favourite package manager:
 
 ```lua
 use({
-	"Pocco81/auto-save.nvim",
+	"okuuva/auto-save.nvim",
 	config = function()
 		 require("auto-save").setup {
 			-- your config goes here
@@ -61,7 +61,7 @@ use({
 	<summary><a href="https://github.com/junegunn/vim-plug">vim-plug</a></summary>
 
 ```vim
-Plug 'Pocco81/auto-save.nvim'
+Plug 'okuuva/auto-save.nvim'
 lua << EOF
 	require("auto-save").setup {
 		-- your config goes here
@@ -129,5 +129,11 @@ vim.api.nvim_set_keymap("n", "<leader>n", ":ASToggle<CR>", {})
 Besides running auto-save at startup (if you have `enabled = true` in your config), you may as well:
 
 - `ASToggle`: toggle auto-save
+
+&nbsp;
+
+### 👋 Acknowledgements
+
+This plugin wouldn't exist without [Pocco81](https://github.com/Pocco81)'s work on the [original](https://github.com/Pocco81/auto-save.nvim).
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@
 Install the plugin with your favourite package manager:
 
 <details>
+	<summary><a href="https://github.com/folke/lazy.nvim">Lazy.nvim</a></summary>
+
+```lua
+{
+	"okuuva/auto-save.nvim",
+	cmd = "ASToggle", -- optional for lazy loading on command
+	event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
+	opts = {
+		-- your config goes here
+		-- or just leave it empty :)
+	},
+},
+```
+
+</details>
+
+<details>
 	<summary><a href="https://github.com/wbthomason/packer.nvim">Packer.nvim</a></summary>
 
 ```lua
@@ -120,6 +137,19 @@ Additionally you may want to set up a key mapping to toggle auto-save:
 
 ```lua
 vim.api.nvim_set_keymap("n", "<leader>n", ":ASToggle<CR>", {})
+```
+
+or as part of the `lazy.nvim` plugin spec:
+
+```lua
+{
+	"okuuva/auto-save.nvim",
+	keys = {
+		{ "<leader>n", ":ASToggle<CR>", desc = "Toggle auto-save" },
+	},
+	...
+},
+
 ```
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -119,9 +119,26 @@ EOF
 }
 ```
 
+### Trigger Events
+
+The `trigger_events` field of the configuration allows the user to customize at which events **auto-save** saves.
+While the default are very sane and should be enough for most usecases, finetuning for extended possibilities is supported.
+
+It is also possible to pass a pattern to a trigger event, if you only want to execute the event on special file patterns:
+
+``` lua
+{
+  trigger_events = {
+    immediate_save = {
+      { "BufLeave", pattern = {"*.c", "*.h"} }
+    }
+  }
+}
+```
+
 ### Condition
 
-The condition field of the configuration allows the user to exclude **auto-save** from saving specific buffers.
+The `condition` field of the configuration allows the user to exclude **auto-save** from saving specific buffers.
 
 Here is an example using a helper function from `auto-save.utils.data` that disables auto-save for specified file types:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <h2 align="center">🧶 auto-save.nvim</h2>
+	<h2 align="center">🧶 auto-save.nvim</h2>
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ This plugin has been renamed from `AutoSave` to `auto-save`, and this repository
 
 ### 📚 Requirements
 
--   Neovim >= 0.5.0
+- Neovim >= 0.5.0
 
 &nbsp;
 
@@ -86,15 +86,16 @@ EOF
 
 ```lua
 {
-    enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
-    execution_message = {
+	enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
+	execution_message = {
+		enabled = true,
 		message = function() -- message to print on save
 			return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
 		end,
 		dim = 0.18, -- dim the color of `message`
 		cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
 	},
-    trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
+	trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
 	-- function that determines whether to save the current buffer or not
 	-- return true: if buffer is ok to be saved
 	-- return false: if it's not ok to be saved
@@ -109,8 +110,8 @@ EOF
 		end
 		return false -- can't save
 	end,
-    write_all_buffers = false, -- write all buffers when the current one meets `condition`
-    debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+	write_all_buffers = false, -- write all buffers when the current one meets `condition`
+	debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
 	callbacks = { -- functions to be executed at different intervals
 		enabling = nil, -- ran when enabling auto-save
 		disabling = nil, -- ran when disabling auto-save

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
     <img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
 </p>
 
-&nbsp;
-
 ### 📋 Features
 
 - automatically save your changes so the world doesn't collapse
@@ -28,13 +26,9 @@
 - multiple callbacks
 - automatically clean the message area
 
-&nbsp;
-
 ### 📚 Requirements
 
 - Neovim >= 0.5.0
-
-&nbsp;
 
 ### 📦 Installation
 
@@ -88,8 +82,6 @@ EOF
 ```
 
 </details>
-
-&nbsp;
 
 ### ⚙️ Configuration
 
@@ -156,23 +148,19 @@ or as part of the `lazy.nvim` plugin spec:
 
 ```
 
-&nbsp;
-
 ### 🪴 Usage
 
 Besides running auto-save at startup (if you have `enabled = true` in your config), you may as well:
 
 - `ASToggle`: toggle auto-save
 
-&nbsp;
-
 ### 🤝 Contributing
 
 - All pull requests are welcome.
 - If you encounter bugs please open an issue.
+- Please use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when commiting.
+  - See [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional) for more details.
 
 ### 👋 Acknowledgements
 
 This plugin wouldn't exist without [Pocco81](https://github.com/Pocco81)'s work on the [original](https://github.com/Pocco81/auto-save.nvim).
-
-&nbsp;

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The plugin fires events at various points during its lifecycle which users can h
 
 - `AutoSaveWritePre` Just before a buffer is getting saved
 - `AutoSaveWritePost` Just after a buffer is getting saved
+- `AutoSaveEnable` Just after enabling the plugin
+- `AutoSaveDisable` Just after disabling the plugin
 
 It will always supply the current buffer in the `data.saved_buffer`
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
+<!-- panvimdoc-ignore-start -->
 <p align="center">
-  <h2 align="center">🧶 auto-save.nvim</h2>
+  <h1 align="center">🧶 auto-save.nvim</h1>
 </p>
 
 <p align="center">
-  Automatically save your changes in NeoVim
+  <b>auto-save.nvim</b> is a lua plugin for automatically saving your changed buffers in Neovim<br>
+  Forked from <a href="https://github.com/Pocco81/auto-save.nvim">auto-save.nvim</a> as active development has stopped
 </p>
 
 <p align="center">
   <a href="https://github.com/okuuva/auto-save.nvim/stargazers">
-    <img alt="Stars" src="https://img.shields.io/github/stars/okuuva/auto-save.nvim?style=for-the-badge&logo=starship&color=C9CBFF&logoColor=D9E0EE&labelColor=302D41"></a>
+    <img alt="Stars" src="https://img.shields.io/github/stars/okuuva/auto-save.nvim?style=for-the-badge">
+  </a>
   <a href="https://github.com/okuuva/auto-save.nvim/issues">
-    <img alt="Issues" src="https://img.shields.io/github/issues/okuuva/auto-save.nvim?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41"></a>
+    <img alt="Issues" src="https://img.shields.io/github/issues/okuuva/auto-save.nvim?style=for-the-badge">
+  </a>
+  <a href="https://github.com/okuuva/auto-save.nvim/blob/main/LICENSE">
+    <img alt="License" src="https://img.shields.io/github/license/okuuva/auto-save.nvim?style=for-the-badge">
+  </a>
   <a href="https://github.com/okuuva/auto-save.nvim">
-    <img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?color=%23DDB6F2&label=SIZE&logo=codesandbox&style=for-the-badge&logoColor=D9E0EE&labelColor=302D41"/></a>
+    <img alt="Repo Size" src="https://img.shields.io/github/repo-size/okuuva/auto-save.nvim?style=for-the-badge"/>
+  </a>
 </p>
 
-### 📋 Features
+<!-- panvimdoc-ignore-end -->
+
+## 📋 Features
 
 - automatically save your changes so the world doesn't collapse
 - highly customizable:
@@ -26,16 +36,15 @@
 - multiple callbacks
 - automatically clean the message area
 
-### 📚 Requirements
+## 📚 Requirements
 
-- Neovim >= 0.5.0
+- Neovim >= 0.8.0
 
-### 📦 Installation
+## 📦 Installation
 
 Install the plugin with your favourite package manager:
 
-<details>
-  <summary><a href="https://github.com/folke/lazy.nvim">Lazy.nvim</a></summary>
+### [Lazy.nvim]("https://github.com/folke/lazy.nvim")
 
 ```lua
 {
@@ -49,10 +58,7 @@ Install the plugin with your favourite package manager:
 },
 ```
 
-</details>
-
-<details>
-  <summary><a href="https://github.com/wbthomason/packer.nvim">Packer.nvim</a></summary>
+### [Packer.nvim]("https://github.com/wbthomason/packer.nvim")
 
 ```lua
 use({
@@ -66,10 +72,7 @@ use({
 })
 ```
 
-</details>
-
-<details>
-  <summary><a href="https://github.com/junegunn/vim-plug">vim-plug</a></summary>
+### [vim-plug]("https://github.com/junegunn/vim-plug")
 
 ```vim
 Plug 'okuuva/auto-save.nvim'
@@ -83,7 +86,7 @@ EOF
 
 </details>
 
-### ⚙️ Configuration
+## ⚙️ Configuration
 
 **auto-save** comes with the following defaults:
 
@@ -118,10 +121,12 @@ EOF
 }
 ```
 
-#### Condition
+### Condition
+
 The condition field of the configuration allows the user to exclude **auto-save** from saving specific buffers.
 
 Here is an example using a helper function from `auto-save.utils.data` that disables auto-save for specified file types:
+
 ```lua
 {
   condition = function(buf)
@@ -138,6 +143,7 @@ Here is an example using a helper function from `auto-save.utils.data` that disa
 ```
 
 You may also exclude `special-buffers` see (`:h buftype` and `:h special-buffers`):
+
 ```lua
 {
   condition = function(buf)
@@ -154,7 +160,7 @@ You may also exclude `special-buffers` see (`:h buftype` and `:h special-buffers
 
 Buffers that are `nomodifiable` are not saved by default.
 
-### 🪴 Usage
+## 🚀 Usage
 
 Besides running auto-save at startup (if you have `enabled = true` in your config), you may as well:
 
@@ -179,14 +185,13 @@ or as part of the `lazy.nvim` plugin spec:
 
 ```
 
-
-### 🤝 Contributing
+## 🤝 Contributing
 
 - All pull requests are welcome.
 - If you encounter bugs please open an issue.
 - Please use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when commiting.
   - See [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional) for more details.
 
-### 👋 Acknowledgements
+## 👋 Acknowledgements
 
 This plugin wouldn't exist without [Pocco81](https://github.com/Pocco81)'s work on the [original](https://github.com/Pocco81/auto-save.nvim).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ EOF
     dim = 0.18, -- dim the color of `message`
     cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
   },
-  trigger_events = {"InsertLeave", "TextChanged"}, -- vim events that trigger auto-save. See :h events
+  trigger_events = { -- See :h events
+    immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
+    defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+    cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
+  },
   -- function that determines whether to save the current buffer or not
   -- return true: if buffer is ok to be saved
   -- return false: if it's not ok to be saved
@@ -122,7 +126,7 @@ EOF
     return false -- can't save
   end,
   write_all_buffers = false, -- write all buffers when the current one meets `condition`
-  debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+  debounce_delay = 1000, -- delay after which a pending save is executed
   callbacks = { -- functions to be executed at different intervals
     enabling = nil, -- ran when enabling auto-save
     disabling = nil, -- ran when disabling auto-save

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*                                Last change: 2023 April 30
+*auto-save.nvim.txt*       For Neovim >= 0.8.0      Last change: 2023 April 30
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 04
+*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 05
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -49,7 +49,7 @@ LAZY.NVIM                              *auto-save.nvim-installation-lazy.nvim*
     {
       "okuuva/auto-save.nvim",
       cmd = "ASToggle", -- optional for lazy loading on command
-      event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
+      event = { "InsertLeave", "TextChanged" }, -- optional for lazy loading on trigger events
       opts = {
         -- your config goes here
         -- or just leave it empty :)

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 03
+*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 04
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,0 +1,219 @@
+*auto-save.nvim.txt*                                Last change: 2023 April 30
+
+==============================================================================
+Table of Contents                           *auto-save.nvim-table-of-contents*
+
+1. Features                                          |auto-save.nvim-features|
+2. Requirements                                  |auto-save.nvim-requirements|
+3. Installation                                  |auto-save.nvim-installation|
+  - Lazy.nvim                          |auto-save.nvim-installation-lazy.nvim|
+  - Packer.nvim                      |auto-save.nvim-installation-packer.nvim|
+  - vim-plug                            |auto-save.nvim-installation-vim-plug|
+4. Configuration                                |auto-save.nvim-configuration|
+  - Condition                         |auto-save.nvim-configuration-condition|
+5. Usage                                                |auto-save.nvim-usage|
+6. Contributing                                  |auto-save.nvim-contributing|
+7. Acknowledgements                          |auto-save.nvim-acknowledgements|
+
+==============================================================================
+1. Features                                          *auto-save.nvim-features*
+
+
+- automatically save your changes so the world doesn’t collapse
+- highly customizable:
+    - conditionals to assert whether to save or not
+    - execution message (it can be dimmed and personalized)
+    - events that trigger auto-save
+- debounce the save with a delay
+- multiple callbacks
+- automatically clean the message area
+
+
+==============================================================================
+2. Requirements                                  *auto-save.nvim-requirements*
+
+
+- Neovim >= 0.8.0
+
+
+==============================================================================
+3. Installation                                  *auto-save.nvim-installation*
+
+Install the plugin with your favourite package manager:
+
+
+LAZY.NVIM                              *auto-save.nvim-installation-lazy.nvim*
+
+>lua
+    {
+      "okuuva/auto-save.nvim",
+      cmd = "ASToggle", -- optional for lazy loading on command
+      event = { "InsertLeave", "TextChanged" } -- optional for lazy loading on trigger events
+      opts = {
+        -- your config goes here
+        -- or just leave it empty :)
+      },
+    },
+<
+
+
+PACKER.NVIM                          *auto-save.nvim-installation-packer.nvim*
+
+>lua
+    use({
+      "okuuva/auto-save.nvim",
+      config = function()
+       require("auto-save").setup {
+         -- your config goes here
+         -- or just leave it empty :)
+       }
+      end,
+    })
+<
+
+
+VIM-PLUG                                *auto-save.nvim-installation-vim-plug*
+
+>vim
+    Plug 'okuuva/auto-save.nvim'
+    lua << EOF
+      require("auto-save").setup {
+        -- your config goes here
+        -- or just leave it empty :)
+      }
+    EOF
+<
+
+
+==============================================================================
+4. Configuration                                *auto-save.nvim-configuration*
+
+**auto-save** comes with the following defaults:
+
+>lua
+    {
+      enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
+      execution_message = {
+        enabled = true,
+        message = function() -- message to print on save
+          return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
+        end,
+        dim = 0.18, -- dim the color of `message`
+        cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
+      },
+      trigger_events = { -- See :h events
+        immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
+        defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+        cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
+      },
+      -- function that takes the buffer handle and determines whether to save the current buffer or not
+      -- return true: if buffer is ok to be saved
+      -- return false: if it's not ok to be saved
+      -- if set to `nil` then no specific condition is applied
+      condition = nil,
+      write_all_buffers = false, -- write all buffers when the current one meets `condition`
+      debounce_delay = 1000, -- delay after which a pending save is executed
+      callbacks = { -- functions to be executed at different intervals
+        before_saving = nil, -- ran before doing the actual save
+      },
+     -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
+      debug = false,
+    }
+<
+
+
+CONDITION                             *auto-save.nvim-configuration-condition*
+
+The condition field of the configuration allows the user to exclude
+**auto-save** from saving specific buffers.
+
+Here is an example using a helper function from `auto-save.utils.data` that
+disables auto-save for specified file types:
+
+>lua
+    {
+      condition = function(buf)
+        local fn = vim.fn
+        local utils = require("auto-save.utils.data")
+    
+        -- don't save for `sql` file types
+        if utils.not_in(fn.getbufvar(buf, "&filetype"), {'sql'}) then
+          return true
+        end
+        return false
+      end
+    }
+<
+
+You may also exclude `special-buffers` see (`:h buftype` and `:h
+special-buffers`):
+
+>lua
+    {
+      condition = function(buf)
+        local fn = vim.fn
+    
+        -- don't save for special-buffers
+        if fn.getbufvar(buf, "&buftype") ~= '' then
+          return false
+        end
+        return true
+      end
+    }
+<
+
+Buffers that are `nomodifiable` are not saved by default.
+
+
+==============================================================================
+5. Usage                                                *auto-save.nvim-usage*
+
+Besides running auto-save at startup (if you have `enabled = true` in your
+config), you may as well:
+
+
+- `ASToggle`toggle auto-save
+
+You may want to set up a key mapping for toggling:
+
+>lua
+    vim.api.nvim_set_keymap("n", "<leader>n", ":ASToggle<CR>", {})
+<
+
+or as part of the `lazy.nvim` plugin spec:
+
+>lua
+    {
+      "okuuva/auto-save.nvim",
+      keys = {
+        { "<leader>n", ":ASToggle<CR>", desc = "Toggle auto-save" },
+      },
+      ...
+    },
+<
+
+
+==============================================================================
+6. Contributing                                  *auto-save.nvim-contributing*
+
+
+- All pull requests are welcome.
+- If you encounter bugs please open an issue.
+- Please use Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/> when commiting.
+    - See @commitlint/config-conventional <https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional> for more details.
+
+
+==============================================================================
+7. Acknowledgements                          *auto-save.nvim-acknowledgements*
+
+This plugin wouldn’t exist without Pocco81 <https://github.com/Pocco81>’s
+work on the original <https://github.com/Pocco81/auto-save.nvim>.
+
+==============================================================================
+8. Links                                                *auto-save.nvim-links*
+
+1. *@commitlint/config-conventional*: 
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 21
+*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 27
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*
@@ -12,13 +12,12 @@ Table of Contents                           *auto-save.nvim-table-of-contents*
 4. Configuration                                |auto-save.nvim-configuration|
   - Condition                         |auto-save.nvim-configuration-condition|
 5. Usage                                                |auto-save.nvim-usage|
-6. 🪝 Events / Callbacks            |auto-save.nvim-🪝-events-/-callbacks|
+6. Events / Callbacks                      |auto-save.nvim-events-/-callbacks|
 7. Contributing                                  |auto-save.nvim-contributing|
 8. Acknowledgements                          |auto-save.nvim-acknowledgements|
 
 ==============================================================================
 1. Features                                          *auto-save.nvim-features*
-
 
 - automatically save your changes so the world doesn’t collapse
 - highly customizable:
@@ -32,7 +31,6 @@ Table of Contents                           *auto-save.nvim-table-of-contents*
 
 ==============================================================================
 2. Requirements                                  *auto-save.nvim-requirements*
-
 
 - Neovim >= 0.8.0
 
@@ -170,7 +168,6 @@ Buffers that are `nomodifiable` are not saved by default.
 Besides running auto-save at startup (if you have `enabled = true` in your
 config), you may as well:
 
-
 - `ASToggle`toggle auto-save
 
 You may want to set up a key mapping for toggling:
@@ -193,11 +190,10 @@ or as part of the `lazy.nvim` plugin spec:
 
 
 ==============================================================================
-6. 🪝 Events / Callbacks            *auto-save.nvim-🪝-events-/-callbacks*
+6. Events / Callbacks                      *auto-save.nvim-events-/-callbacks*
 
 The plugin fires events at various points during its lifecycle which users can
 hook into:
-
 
 - `AutoSaveWritePre` Just before a buffer is getting saved
 - `AutoSaveWritePost` Just after a buffer is getting saved
@@ -227,7 +223,6 @@ If you want more Events, feel free to open an issue.
 
 ==============================================================================
 7. Contributing                                  *auto-save.nvim-contributing*
-
 
 - All pull requests are welcome.
 - If you encounter bugs please open an issue.

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 05
+*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 21
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*
@@ -113,6 +113,7 @@ VIM-PLUG                                *auto-save.nvim-installation-vim-plug*
       -- if set to `nil` then no specific condition is applied
       condition = nil,
       write_all_buffers = false, -- write all buffers when the current one meets `condition`
+      noautocmd = false, -- do not execute autocmds when saving
       debounce_delay = 1000, -- delay after which a pending save is executed
      -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
       debug = false,

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 27
+*auto-save.nvim.txt*     For Neovim >= 0.8.0     Last change: 2023 November 08
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*
@@ -10,6 +10,7 @@ Table of Contents                           *auto-save.nvim-table-of-contents*
   - Packer.nvim                      |auto-save.nvim-installation-packer.nvim|
   - vim-plug                            |auto-save.nvim-installation-vim-plug|
 4. Configuration                                |auto-save.nvim-configuration|
+  - Trigger Events               |auto-save.nvim-configuration-trigger-events|
   - Condition                         |auto-save.nvim-configuration-condition|
 5. Usage                                                |auto-save.nvim-usage|
 6. Events / Callbacks                      |auto-save.nvim-events-/-callbacks|
@@ -119,9 +120,29 @@ VIM-PLUG                                *auto-save.nvim-installation-vim-plug*
 <
 
 
+TRIGGER EVENTS                   *auto-save.nvim-configuration-trigger-events*
+
+The `trigger_events` field of the configuration allows the user to customize at
+which events **auto-save** saves. While the default are very sane and should be
+enough for most usecases, finetuning for extended possibilities is supported.
+
+It is also possible to pass a pattern to a trigger event, if you only want to
+execute the event on special file patterns:
+
+>lua
+    {
+      trigger_events = {
+        immediate_save = {
+          { "BufLeave", pattern = {".c", ".h"} }
+        }
+      }
+    }
+<
+
+
 CONDITION                             *auto-save.nvim-configuration-condition*
 
-The condition field of the configuration allows the user to exclude
+The `condition` field of the configuration allows the user to exclude
 **auto-save** from saving specific buffers.
 
 Here is an example using a helper function from `auto-save.utils.data` that

--- a/doc/auto-save.nvim.txt
+++ b/doc/auto-save.nvim.txt
@@ -1,4 +1,4 @@
-*auto-save.nvim.txt*       For Neovim >= 0.8.0      Last change: 2023 April 30
+*auto-save.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 July 03
 
 ==============================================================================
 Table of Contents                           *auto-save.nvim-table-of-contents*
@@ -12,8 +12,9 @@ Table of Contents                           *auto-save.nvim-table-of-contents*
 4. Configuration                                |auto-save.nvim-configuration|
   - Condition                         |auto-save.nvim-configuration-condition|
 5. Usage                                                |auto-save.nvim-usage|
-6. Contributing                                  |auto-save.nvim-contributing|
-7. Acknowledgements                          |auto-save.nvim-acknowledgements|
+6. 🪝 Events / Callbacks            |auto-save.nvim-🪝-events-/-callbacks|
+7. Contributing                                  |auto-save.nvim-contributing|
+8. Acknowledgements                          |auto-save.nvim-acknowledgements|
 
 ==============================================================================
 1. Features                                          *auto-save.nvim-features*
@@ -25,7 +26,7 @@ Table of Contents                           *auto-save.nvim-table-of-contents*
     - execution message (it can be dimmed and personalized)
     - events that trigger auto-save
 - debounce the save with a delay
-- multiple callbacks
+- hook into the lifecycle with autocommands
 - automatically clean the message area
 
 
@@ -113,9 +114,6 @@ VIM-PLUG                                *auto-save.nvim-installation-vim-plug*
       condition = nil,
       write_all_buffers = false, -- write all buffers when the current one meets `condition`
       debounce_delay = 1000, -- delay after which a pending save is executed
-      callbacks = { -- functions to be executed at different intervals
-        before_saving = nil, -- ran before doing the actual save
-      },
      -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
       debug = false,
     }
@@ -194,7 +192,40 @@ or as part of the `lazy.nvim` plugin spec:
 
 
 ==============================================================================
-6. Contributing                                  *auto-save.nvim-contributing*
+6. 🪝 Events / Callbacks            *auto-save.nvim-🪝-events-/-callbacks*
+
+The plugin fires events at various points during its lifecycle which users can
+hook into:
+
+
+- `AutoSaveWritePre` Just before a buffer is getting saved
+- `AutoSaveWritePost` Just after a buffer is getting saved
+
+It will always supply the current buffer in the `data.saved_buffer`
+
+An example to always print the file name before a file is getting saved (use
+`:messages` if the execution message swallows the print):
+
+>lua
+    local group = vim.api.nvim_create_augroup('autosave', {})
+    
+    vim.api.nvim_create_autocmd('User', {
+        pattern = 'AutoSaveWritePre',
+        group = group,
+        callback = function(opts)
+            if opts.data.saved_buffer ~= nil then
+                local filename = vim.api.nvim_buf_get_name(opts.data.saved_buffer)
+                print('We are about to save ' .. filename .. ' get ready captain!')
+            end
+        end,
+    })
+<
+
+If you want more Events, feel free to open an issue.
+
+
+==============================================================================
+7. Contributing                                  *auto-save.nvim-contributing*
 
 
 - All pull requests are welcome.
@@ -204,13 +235,13 @@ or as part of the `lazy.nvim` plugin spec:
 
 
 ==============================================================================
-7. Acknowledgements                          *auto-save.nvim-acknowledgements*
+8. Acknowledgements                          *auto-save.nvim-acknowledgements*
 
 This plugin wouldn’t exist without Pocco81 <https://github.com/Pocco81>’s
 work on the original <https://github.com/Pocco81/auto-save.nvim>.
 
 ==============================================================================
-8. Links                                                *auto-save.nvim-links*
+9. Links                                                *auto-save.nvim-links*
 
 1. *@commitlint/config-conventional*: 
 

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -12,11 +12,11 @@ Config = {
       cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
     },
     trigger_events = { -- See :h events
-      --- @type nil|string[]
+      --- @type TriggerEvent[]?
       immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
-      --- @type nil|string[]
+      --- @type TriggerEvent[]?
       defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
-      --- @type nil|string[]
+      --- @type TriggerEvent[]?
       cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
     },
     -- function that takes the buffer handle and determines whether to save the current buffer or not

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -23,6 +23,7 @@ Config = {
     --- @type nil|fun(buf: number): boolean
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
+    noautocmd = false, -- do not execute autocmds when saving
     debounce_delay = 1000, -- delay after which a pending save is executed
     -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
     debug = false, -- print debug messages, set to `true` to enable

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -1,8 +1,10 @@
+--- @class Config
 Config = {
   opts = {
     enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
     execution_message = {
       enabled = true,
+      --- @type string|fun(): string
       message = function() -- message to print on save
         return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
       end,
@@ -18,6 +20,7 @@ Config = {
     -- return true: if buffer is ok to be saved
     -- return false: if it's not ok to be saved
     -- if set to `nil` then no specific condition is applied
+    --- @type nil|fun(buf: number): boolean
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -21,9 +21,6 @@ Config = {
     condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed
-    callbacks = { -- functions to be executed at different intervals
-      before_saving = nil, -- ran before doing the actual save
-    },
     -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
     debug = false, -- print debug messages, set to `true` to enable
   },

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -22,11 +22,10 @@ Config = {
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed
     callbacks = { -- functions to be executed at different intervals
-      enabling = nil, -- ran when enabling auto-save
-      disabling = nil, -- ran when disabling auto-save
       before_saving = nil, -- ran before doing the actual save
-      after_saving = nil, -- ran after doing the actual save
     },
+    -- log debug messages to 'auto-save.log' file in neovim cache directory, set to `true` to enable
+    debug = false, -- print debug messages, set to `true` to enable
   },
 }
 

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -12,8 +12,11 @@ Config = {
       cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
     },
     trigger_events = { -- See :h events
+      --- @type nil|string[]
       immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
+      --- @type nil|string[]
       defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+      --- @type nil|string[]
       cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
     },
     -- function that takes the buffer handle and determines whether to save the current buffer or not

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -1,46 +1,46 @@
 Config = {
-	opts = {
-		enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
-		execution_message = {
-			enabled = true,
-			message = function() -- message to print on save
-				return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
-			end,
-			dim = 0.18, -- dim the color of `message`
-			cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
-		},
-		trigger_events = { "InsertLeave", "TextChanged" }, -- vim events that trigger auto-save. See :h events
-		-- function that determines whether to save the current buffer or not
-		-- return true: if buffer is ok to be saved
-		-- return false: if it's not ok to be saved
-		condition = function(buf)
-			local fn = vim.fn
-			local utils = require("auto-save.utils.data")
+  opts = {
+    enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
+    execution_message = {
+      enabled = true,
+      message = function() -- message to print on save
+        return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
+      end,
+      dim = 0.18, -- dim the color of `message`
+      cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
+    },
+    trigger_events = { "InsertLeave", "TextChanged" }, -- vim events that trigger auto-save. See :h events
+    -- function that determines whether to save the current buffer or not
+    -- return true: if buffer is ok to be saved
+    -- return false: if it's not ok to be saved
+    condition = function(buf)
+      local fn = vim.fn
+      local utils = require("auto-save.utils.data")
 
-			if fn.getbufvar(buf, "&modifiable") == 1 and utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
-				return true -- met condition(s), can save
-			end
-			return false -- can't save
-		end,
-		write_all_buffers = false, -- write all buffers when the current one meets `condition`
-		debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
-		callbacks = { -- functions to be executed at different intervals
-			enabling = nil, -- ran when enabling auto-save
-			disabling = nil, -- ran when disabling auto-save
-			before_asserting_save = nil, -- ran before checking `condition`
-			before_saving = nil, -- ran before doing the actual save
-			after_saving = nil, -- ran after doing the actual save
-		},
-	},
+      if fn.getbufvar(buf, "&modifiable") == 1 and utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
+        return true -- met condition(s), can save
+      end
+      return false -- can't save
+    end,
+    write_all_buffers = false, -- write all buffers when the current one meets `condition`
+    debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+    callbacks = { -- functions to be executed at different intervals
+      enabling = nil, -- ran when enabling auto-save
+      disabling = nil, -- ran when disabling auto-save
+      before_asserting_save = nil, -- ran before checking `condition`
+      before_saving = nil, -- ran before doing the actual save
+      after_saving = nil, -- ran after doing the actual save
+    },
+  },
 }
 
 function Config:set_options(opts)
-	opts = opts or {}
-	self.opts = vim.tbl_deep_extend("keep", opts, self.opts)
+  opts = opts or {}
+  self.opts = vim.tbl_deep_extend("keep", opts, self.opts)
 end
 
 function Config:get_options()
-	return self.opts
+  return self.opts
 end
 
 return Config

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -2,6 +2,7 @@ Config = {
 	opts = {
 		enabled = true, -- start auto-save when the plugin is loaded (i.e. when your package manager loads it)
 		execution_message = {
+			enabled = true,
 			message = function() -- message to print on save
 				return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
 			end,

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -11,27 +11,19 @@ Config = {
     },
     trigger_events = { -- See :h events
       immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
-    defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
-    cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
+      defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+      cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
     },
-    -- function that determines whether to save the current buffer or not
+    -- function that takes the buffer handle and determines whether to save the current buffer or not
     -- return true: if buffer is ok to be saved
     -- return false: if it's not ok to be saved
-    condition = function(buf)
-      local fn = vim.fn
-      local utils = require("auto-save.utils.data")
-
-      if fn.getbufvar(buf, "&modifiable") == 1 and utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
-        return true -- met condition(s), can save
-      end
-      return false -- can't save
-    end,
+    -- if set to `nil` then no specific condition is applied
+    condition = nil,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
     debounce_delay = 1000, -- delay after which a pending save is executed
     callbacks = { -- functions to be executed at different intervals
       enabling = nil, -- ran when enabling auto-save
       disabling = nil, -- ran when disabling auto-save
-      before_asserting_save = nil, -- ran before checking `condition`
       before_saving = nil, -- ran before doing the actual save
       after_saving = nil, -- ran after doing the actual save
     },

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -16,8 +16,7 @@ Config = {
 			local fn = vim.fn
 			local utils = require("auto-save.utils.data")
 
-			if fn.getbufvar(buf, "&modifiable") == 1 and
-				utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
+			if fn.getbufvar(buf, "&modifiable") == 1 and utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
 				return true -- met condition(s), can save
 			end
 			return false -- can't save

--- a/lua/auto-save/config.lua
+++ b/lua/auto-save/config.lua
@@ -9,7 +9,11 @@ Config = {
       dim = 0.18, -- dim the color of `message`
       cleaning_interval = 1250, -- (milliseconds) automatically clean MsgArea after displaying `message`. See :h MsgArea
     },
-    trigger_events = { "InsertLeave", "TextChanged" }, -- vim events that trigger auto-save. See :h events
+    trigger_events = { -- See :h events
+      immediate_save = { "BufLeave", "FocusLost" }, -- vim events that trigger an immediate save
+    defer_save = { "InsertLeave", "TextChanged" }, -- vim events that trigger a deferred save (saves after `debounce_delay`)
+    cancel_defered_save = { "InsertEnter" }, -- vim events that cancel a pending deferred save
+    },
     -- function that determines whether to save the current buffer or not
     -- return true: if buffer is ok to be saved
     -- return false: if it's not ok to be saved
@@ -23,7 +27,7 @@ Config = {
       return false -- can't save
     end,
     write_all_buffers = false, -- write all buffers when the current one meets `condition`
-    debounce_delay = 135, -- saves the file at most every `debounce_delay` milliseconds
+    debounce_delay = 1000, -- delay after which a pending save is executed
     callbacks = { -- functions to be executed at different intervals
       enabling = nil, -- ran when enabling auto-save
       disabling = nil, -- ran when disabling auto-save

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -15,164 +15,164 @@ local BLACK = "#000000"
 local WHITE = "#ffffff"
 
 api.nvim_create_augroup("AutoSave", {
-	clear = true,
+  clear = true,
 })
 
 local global_vars = {}
 
 local function set_buf_var(buf, name, value)
-	if buf == nil then
-		global_vars[name] = value
-	else
-		if api.nvim_buf_is_valid(buf) then
-			api.nvim_buf_set_var(buf, "autosave_" .. name, value)
-		end
-	end
+  if buf == nil then
+    global_vars[name] = value
+  else
+    if api.nvim_buf_is_valid(buf) then
+      api.nvim_buf_set_var(buf, "autosave_" .. name, value)
+    end
+  end
 end
 
 local function get_buf_var(buf, name)
-	if buf == nil then
-		return global_vars[name]
-	end
-	local success, mod = pcall(api.nvim_buf_get_var, buf, "autosave_" .. name)
-	return success and mod or nil
+  if buf == nil then
+    return global_vars[name]
+  end
+  local success, mod = pcall(api.nvim_buf_get_var, buf, "autosave_" .. name)
+  return success and mod or nil
 end
 
 local function debounce(lfn, duration)
-	local function inner_debounce()
-		local buf = api.nvim_get_current_buf()
-		if not get_buf_var(buf, "queued") then
-			vim.defer_fn(function()
-				set_buf_var(buf, "queued", false)
-				lfn(buf)
-			end, duration)
-			set_buf_var(buf, "queued", true)
-		end
-	end
+  local function inner_debounce()
+    local buf = api.nvim_get_current_buf()
+    if not get_buf_var(buf, "queued") then
+      vim.defer_fn(function()
+        set_buf_var(buf, "queued", false)
+        lfn(buf)
+      end, duration)
+      set_buf_var(buf, "queued", true)
+    end
+  end
 
-	return inner_debounce
+  return inner_debounce
 end
 
 local function echo_execution_message()
-	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
-		or cnf.opts.execution_message.message
-	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
-	if cnf.opts.execution_message.cleaning_interval > 0 then
-		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
-			cmd([[echon '']])
-		end)
-	end
+  local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+    or cnf.opts.execution_message.message
+  api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
+  if cnf.opts.execution_message.cleaning_interval > 0 then
+    fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
+      cmd([[echon '']])
+    end)
+  end
 end
 
 function M.save(buf)
-	buf = buf or api.nvim_get_current_buf()
+  buf = buf or api.nvim_get_current_buf()
 
-	callback("before_asserting_save")
+  callback("before_asserting_save")
 
-	if cnf.opts.condition(buf) == false then
-		return
-	end
+  if cnf.opts.condition(buf) == false then
+    return
+  end
 
-	if not api.nvim_buf_get_option(buf, "modified") then
-		return
-	end
+  if not api.nvim_buf_get_option(buf, "modified") then
+    return
+  end
 
-	callback("before_saving")
+  callback("before_saving")
 
-	if g.auto_save_abort == true then
-		return
-	end
+  if g.auto_save_abort == true then
+    return
+  end
 
-	if cnf.opts.write_all_buffers then
-		cmd("silent! wall")
-	else
-		api.nvim_buf_call(buf, function()
-			cmd("silent! write")
-		end)
-	end
+  if cnf.opts.write_all_buffers then
+    cmd("silent! wall")
+  else
+    api.nvim_buf_call(buf, function()
+      cmd("silent! write")
+    end)
+  end
 
-	callback("after_saving")
+  callback("after_saving")
 
-	if cnf.opts.execution_message.enabled == true then
-		echo_execution_message()
-	end
+  if cnf.opts.execution_message.enabled == true then
+    echo_execution_message()
+  end
 end
 
 local save_func = nil
 
 local function perform_save()
-	g.auto_save_abort = false
-	if save_func == nil then
-		save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
-	end
-	save_func()
+  g.auto_save_abort = false
+  if save_func == nil then
+    save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
+  end
+  save_func()
 end
 
 function M.on()
-	api.nvim_create_autocmd(cnf.opts.trigger_events, {
-		callback = function()
-			perform_save()
-		end,
-		pattern = "*",
-		group = "AutoSave",
-	})
+  api.nvim_create_autocmd(cnf.opts.trigger_events, {
+    callback = function()
+      perform_save()
+    end,
+    pattern = "*",
+    group = "AutoSave",
+  })
 
-	api.nvim_create_autocmd({ "VimEnter", "ColorScheme", "UIEnter" }, {
-		callback = function()
-			vim.schedule(function()
-				if cnf.opts.execution_message.dim > 0 then
-					MSG_AREA = colors.get_hl("MsgArea")
-					if MSG_AREA.foreground ~= nil then
-						MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
-						local foreground = (
-							o.background == "dark"
-								and colors.darken(
-									(MSG_AREA.background or BLACK),
-									cnf.opts.execution_message.dim,
-									MSG_AREA.foreground or BLACK
-								)
-							or colors.lighten(
-								(MSG_AREA.background or WHITE),
-								cnf.opts.execution_message.dim,
-								MSG_AREA.foreground or WHITE
-							)
-						)
+  api.nvim_create_autocmd({ "VimEnter", "ColorScheme", "UIEnter" }, {
+    callback = function()
+      vim.schedule(function()
+        if cnf.opts.execution_message.dim > 0 then
+          MSG_AREA = colors.get_hl("MsgArea")
+          if MSG_AREA.foreground ~= nil then
+            MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
+            local foreground = (
+              o.background == "dark"
+                and colors.darken(
+                  (MSG_AREA.background or BLACK),
+                  cnf.opts.execution_message.dim,
+                  MSG_AREA.foreground or BLACK
+                )
+              or colors.lighten(
+                (MSG_AREA.background or WHITE),
+                cnf.opts.execution_message.dim,
+                MSG_AREA.foreground or WHITE
+              )
+            )
 
-						colors.highlight("AutoSaveText", { fg = foreground })
-						AUTO_SAVE_COLOR = "AutoSaveText"
-					end
-				end
-			end)
-		end,
-		pattern = "*",
-		group = "AutoSave",
-	})
+            colors.highlight("AutoSaveText", { fg = foreground })
+            AUTO_SAVE_COLOR = "AutoSaveText"
+          end
+        end
+      end)
+    end,
+    pattern = "*",
+    group = "AutoSave",
+  })
 
-	callback("enabling")
-	autosave_running = true
+  callback("enabling")
+  autosave_running = true
 end
 
 function M.off()
-	api.nvim_create_augroup("AutoSave", {
-		clear = true,
-	})
+  api.nvim_create_augroup("AutoSave", {
+    clear = true,
+  })
 
-	callback("disabling")
-	autosave_running = false
+  callback("disabling")
+  autosave_running = false
 end
 
 function M.toggle()
-	if autosave_running then
-		M.off()
-		echo("off")
-	else
-		M.on()
-		echo("on")
-	end
+  if autosave_running then
+    M.off()
+    echo("off")
+  else
+    M.on()
+    echo("on")
+  end
 end
 
 function M.setup(custom_opts)
-	cnf:set_options(custom_opts)
+  cnf:set_options(custom_opts)
 end
 
 return M

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -81,11 +81,12 @@ local function save(buf)
 
   autocmds.exec_autocmd("AutoSaveWritePre", buf)
 
+  local noautocmd = cnf.opts.noautocmd and "noautocmd " or ""
   if cnf.opts.write_all_buffers then
-    cmd("silent! wall")
+    cmd(noautocmd .. "silent! wall")
   else
     api.nvim_buf_call(buf, function()
-      cmd("silent! write")
+      cmd(noautocmd .. "silent! write")
     end)
   end
 

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -112,7 +112,7 @@ local function defer_save(buf)
 end
 
 function M.on()
-  local augroup = autocmds.create_augroup()
+  local augroup = autocmds.create_augroup({ clear = true })
 
   api.nvim_create_autocmd(cnf.opts.trigger_events.immediate_save, {
     callback = function(opts)

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -79,7 +79,7 @@ local function save(buf)
     return
   end
 
-  autocmds.exec_autocmd("AutoSaveWritePre", buf)
+  autocmds.exec_autocmd("AutoSaveWritePre", { saved_buffer = buf })
 
   local noautocmd = cnf.opts.noautocmd and "noautocmd " or ""
   if cnf.opts.write_all_buffers then
@@ -90,7 +90,7 @@ local function save(buf)
     end)
   end
 
-  autocmds.exec_autocmd("AutoSaveWritePost", buf)
+  autocmds.exec_autocmd("AutoSaveWritePost", { saved_buffer = buf })
   logger.log(buf, "Saved buffer")
 
   if cnf.opts.execution_message.enabled == true then
@@ -163,12 +163,16 @@ function M.on()
   })
 
   autosave_running = true
+
+  autocmds.exec_autocmd("AutoSaveEnable")
 end
 
 function M.off()
   autocmds.create_augroup({ clear = true })
 
   autosave_running = false
+
+  autocmds.exec_autocmd("AutoSaveDisable")
 end
 
 function M.toggle()

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -112,10 +112,13 @@ function M.save(buf)
 	end
 end
 
-local save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
+local save_func = nil
 
 local function perform_save()
 	g.auto_save_abort = false
+	if save_func == nil then
+		save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
+	end
 	save_func()
 end
 

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -117,40 +117,33 @@ function M.on()
   local augroup = autocmds.create_augroup({ clear = true })
 
   local events = cnf.opts.trigger_events
-
-  if events.immediate_save ~= nil and #events.immediate_save > 0 then
-    api.nvim_create_autocmd(events.immediate_save, {
-      callback = function(opts)
-        if should_be_saved(opts.buf) then
-          immediate_save(opts.buf)
-        end
-      end,
-      group = augroup,
-      desc = "Immediately save a buffer",
-    })
-  end
-  if events.defer_save ~= nil and #events.defer_save > 0 then
-    api.nvim_create_autocmd(events.defer_save, {
-      callback = function(opts)
-        if should_be_saved(opts.buf) then
-          defer_save(opts.buf)
-        end
-      end,
-      group = augroup,
-      desc = "Save a buffer after the `debounce_delay`",
-    })
-  end
-  if events.cancel_defered_save ~= nil and #events.cancel_defered_save > 0 then
-    api.nvim_create_autocmd(events.cancel_defered_save, {
-      callback = function(opts)
-        if should_be_saved(opts.buf) then
-          cancel_timer(opts.buf)
-        end
-      end,
-      group = augroup,
-      desc = "Cancel a pending save timer for a buffer",
-    })
-  end
+  autocmds.create_autocmd_for_trigger_events(events.immediate_save, {
+    callback = function(opts)
+      if should_be_saved(opts.buf) then
+        immediate_save(opts.buf)
+      end
+    end,
+    group = augroup,
+    desc = "Immediately save a buffer",
+  })
+  autocmds.create_autocmd_for_trigger_events(events.defer_save, {
+    callback = function(opts)
+      if should_be_saved(opts.buf) then
+        defer_save(opts.buf)
+      end
+    end,
+    group = augroup,
+    desc = "Save a buffer after the `debounce_delay`",
+  })
+  autocmds.create_autocmd_for_trigger_events(events.cancel_defered_save, {
+    callback = function(opts)
+      if should_be_saved(opts.buf) then
+        cancel_timer(opts.buf)
+      end
+    end,
+    group = augroup,
+    desc = "Cancel a pending save timer for a buffer",
+  })
 
   local function setup_dimming()
     if cnf.opts.execution_message.enabled then

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -12,7 +12,7 @@ local cmd = vim.cmd
 local schedule = vim.schedule
 
 local logger
-local autosave_running
+local autosave_running = nil
 
 autocmds.create_augroup({ clear = true })
 
@@ -183,6 +183,14 @@ end
 function M.setup(custom_opts)
   cnf:set_options(custom_opts)
   logger = require("auto-save.utils.logging").new(cnf:get_options())
+
+  if autosave_running == nil then
+    if cnf.opts.enabled then
+      M.on()
+    else
+      M.off()
+    end
+  end
 end
 
 return M

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -15,185 +15,175 @@ local BLACK = "#000000"
 local WHITE = "#ffffff"
 
 api.nvim_create_augroup("AutoSave", {
-    clear = true,
+	clear = true,
 })
 
 local global_vars = {}
 
 local function set_buf_var(buf, name, value)
-    if buf == nil then
-        global_vars[name] = value
-    else
-        if api.nvim_buf_is_valid(buf) then
-            api.nvim_buf_set_var(buf, "autosave_" .. name, value)
-        end
-    end
+	if buf == nil then
+		global_vars[name] = value
+	else
+		if api.nvim_buf_is_valid(buf) then
+			api.nvim_buf_set_var(buf, "autosave_" .. name, value)
+		end
+	end
 end
 
 local function get_buf_var(buf, name)
-    if buf == nil then
-        return global_vars[name]
-    end
-    local success, mod = pcall(api.nvim_buf_get_var, buf, "autosave_" .. name)
-    return success and mod or nil
+	if buf == nil then
+		return global_vars[name]
+	end
+	local success, mod = pcall(api.nvim_buf_get_var, buf, "autosave_" .. name)
+	return success and mod or nil
 end
 
 local function debounce(lfn, duration)
-    local function inner_debounce()
-        local buf = api.nvim_get_current_buf()
-        if not get_buf_var(buf, "queued") then
-            vim.defer_fn(function()
-                set_buf_var(buf, "queued", false)
-                lfn(buf)
-            end, duration)
-            set_buf_var(buf, "queued", true)
-        end
-    end
+	local function inner_debounce()
+		local buf = api.nvim_get_current_buf()
+		if not get_buf_var(buf, "queued") then
+			vim.defer_fn(function()
+				set_buf_var(buf, "queued", false)
+				lfn(buf)
+			end, duration)
+			set_buf_var(buf, "queued", true)
+		end
+	end
 
-    return inner_debounce
+	return inner_debounce
 end
 
 function M.save(buf)
-    buf = buf or api.nvim_get_current_buf()
+	buf = buf or api.nvim_get_current_buf()
 
-    callback("before_asserting_save")
+	callback("before_asserting_save")
 
-    if cnf.opts.condition(buf) == false then
-        return
-    end
+	if cnf.opts.condition(buf) == false then
+		return
+	end
 
-    if not api.nvim_buf_get_option(buf, "modified") then
-        return
-    end
+	if not api.nvim_buf_get_option(buf, "modified") then
+		return
+	end
 
-    callback("before_saving")
+	callback("before_saving")
 
-    if g.auto_save_abort == true then
-        return
-    end
+	if g.auto_save_abort == true then
+		return
+	end
 
-    if cnf.opts.write_all_buffers then
-        cmd("silent! wall")
-    else
-        api.nvim_buf_call(buf, function()
-            cmd("silent! write")
-        end)
-    end
+	if cnf.opts.write_all_buffers then
+		cmd("silent! wall")
+	else
+		api.nvim_buf_call(buf, function()
+			cmd("silent! write")
+		end)
+	end
 
-    callback("after_saving")
+	callback("after_saving")
 
-    api.nvim_echo(
-        {
-            {
-                (
-                    type(cnf.opts.execution_message.message) == "function"
-                        and cnf.opts.execution_message.message()
-                    or cnf.opts.execution_message.message
-                ),
-                AUTO_SAVE_COLOR,
-            },
-        },
-        true,
-        {}
-    )
-    if cnf.opts.execution_message.cleaning_interval > 0 then
-        fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
-            cmd([[echon '']])
-        end)
-    end
-    api.nvim_echo({
-        {
-            (
-                type(cnf.opts.execution_message.message) == "function"
-                    and cnf.opts.execution_message.message()
-                or cnf.opts.execution_message.message
-            ),
-            AUTO_SAVE_COLOR,
-        },
-    }, true, {})
-    if cnf.opts.execution_message.cleaning_interval > 0 then
-        fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
-            cmd([[echon '']])
-        end)
-    end
+	api.nvim_echo({
+		{
+			(
+				type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+				or cnf.opts.execution_message.message
+			),
+			AUTO_SAVE_COLOR,
+		},
+	}, true, {})
+	if cnf.opts.execution_message.cleaning_interval > 0 then
+		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
+			cmd([[echon '']])
+		end)
+	end
+	api.nvim_echo({
+		{
+			(
+				type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+				or cnf.opts.execution_message.message
+			),
+			AUTO_SAVE_COLOR,
+		},
+	}, true, {})
+	if cnf.opts.execution_message.cleaning_interval > 0 then
+		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
+			cmd([[echon '']])
+		end)
+	end
 end
 
-local save_func = (
-    cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save
-)
+local save_func = (cnf.opts.debounce_delay > 0 and debounce(M.save, cnf.opts.debounce_delay) or M.save)
 
 local function perform_save()
-    g.auto_save_abort = false
-    save_func()
+	g.auto_save_abort = false
+	save_func()
 end
 
 function M.on()
-    api.nvim_create_autocmd(cnf.opts.trigger_events, {
-        callback = function()
-            perform_save()
-        end,
-        pattern = "*",
-        group = "AutoSave",
-    })
+	api.nvim_create_autocmd(cnf.opts.trigger_events, {
+		callback = function()
+			perform_save()
+		end,
+		pattern = "*",
+		group = "AutoSave",
+	})
 
-    api.nvim_create_autocmd({ "VimEnter", "ColorScheme", "UIEnter" }, {
-        callback = function()
-            vim.schedule(function()
-                if cnf.opts.execution_message.dim > 0 then
-                    MSG_AREA = colors.get_hl("MsgArea")
-                    if MSG_AREA.foreground ~= nil then
-                        MSG_AREA.background = (
-                            MSG_AREA.background or colors.get_hl("Normal")["background"]
-                        )
-                        local foreground = (
-                            o.background == "dark"
-                                and colors.darken(
-                                    (MSG_AREA.background or BLACK),
-                                    cnf.opts.execution_message.dim,
-                                    MSG_AREA.foreground or BLACK
-                                )
-                            or colors.lighten(
-                                (MSG_AREA.background or WHITE),
-                                cnf.opts.execution_message.dim,
-                                MSG_AREA.foreground or WHITE
-                            )
-                        )
+	api.nvim_create_autocmd({ "VimEnter", "ColorScheme", "UIEnter" }, {
+		callback = function()
+			vim.schedule(function()
+				if cnf.opts.execution_message.dim > 0 then
+					MSG_AREA = colors.get_hl("MsgArea")
+					if MSG_AREA.foreground ~= nil then
+						MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
+						local foreground = (
+							o.background == "dark"
+								and colors.darken(
+									(MSG_AREA.background or BLACK),
+									cnf.opts.execution_message.dim,
+									MSG_AREA.foreground or BLACK
+								)
+							or colors.lighten(
+								(MSG_AREA.background or WHITE),
+								cnf.opts.execution_message.dim,
+								MSG_AREA.foreground or WHITE
+							)
+						)
 
-                        colors.highlight("AutoSaveText", { fg = foreground })
-                        AUTO_SAVE_COLOR = "AutoSaveText"
-                    end
-                end
-            end)
-        end,
-        pattern = "*",
-        group = "AutoSave",
-    })
+						colors.highlight("AutoSaveText", { fg = foreground })
+						AUTO_SAVE_COLOR = "AutoSaveText"
+					end
+				end
+			end)
+		end,
+		pattern = "*",
+		group = "AutoSave",
+	})
 
-    callback("enabling")
-    autosave_running = true
+	callback("enabling")
+	autosave_running = true
 end
 
 function M.off()
-    api.nvim_create_augroup("AutoSave", {
-        clear = true,
-    })
+	api.nvim_create_augroup("AutoSave", {
+		clear = true,
+	})
 
-    callback("disabling")
-    autosave_running = false
+	callback("disabling")
+	autosave_running = false
 end
 
 function M.toggle()
-    if autosave_running then
-        M.off()
-        echo("off")
-    else
-        M.on()
-        echo("on")
-    end
+	if autosave_running then
+		M.off()
+		echo("off")
+	else
+		M.on()
+		echo("on")
+	end
 end
 
 function M.setup(custom_opts)
-    cnf:set_options(custom_opts)
+	cnf:set_options(custom_opts)
 end
 
 return M

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -116,33 +116,41 @@ end
 function M.on()
   local augroup = autocmds.create_augroup({ clear = true })
 
-  api.nvim_create_autocmd(cnf.opts.trigger_events.immediate_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        immediate_save(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Immediately save a buffer",
-  })
-  api.nvim_create_autocmd(cnf.opts.trigger_events.defer_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        defer_save(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Save a buffer after the `debounce_delay`",
-  })
-  api.nvim_create_autocmd(cnf.opts.trigger_events.cancel_defered_save, {
-    callback = function(opts)
-      if should_be_saved(opts.buf) then
-        cancel_timer(opts.buf)
-      end
-    end,
-    group = augroup,
-    desc = "Cancel a pending save timer for a buffer",
-  })
+  local events = cnf.opts.trigger_events
+
+  if events.immediate_save ~= nil and #events.immediate_save > 0 then
+    api.nvim_create_autocmd(events.immediate_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          immediate_save(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Immediately save a buffer",
+    })
+  end
+  if events.defer_save ~= nil and #events.defer_save > 0 then
+    api.nvim_create_autocmd(events.defer_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          defer_save(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Save a buffer after the `debounce_delay`",
+    })
+  end
+  if events.cancel_defered_save ~= nil and #events.cancel_defered_save > 0 then
+    api.nvim_create_autocmd(events.cancel_defered_save, {
+      callback = function(opts)
+        if should_be_saved(opts.buf) then
+          cancel_timer(opts.buf)
+        end
+      end,
+      group = augroup,
+      desc = "Cancel a pending save timer for a buffer",
+    })
+  end
 
   local function setup_dimming()
     if cnf.opts.execution_message.enabled then

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -82,15 +82,14 @@ function M.save(buf)
 
 	callback("after_saving")
 
-	api.nvim_echo({
-		{
-			(
-				type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
-				or cnf.opts.execution_message.message
-			),
-			AUTO_SAVE_COLOR,
-		},
-	}, true, {})
+	if cnf.opts.execution_message.enabled == true then
+		echo_execution_message()
+	end
+end
+
+local function echo_execution_message()
+	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message
+	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
 	if cnf.opts.execution_message.cleaning_interval > 0 then
 		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
 			cmd([[echon '']])

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -88,22 +88,9 @@ function M.save(buf)
 end
 
 local function echo_execution_message()
-	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message
+	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+		or cnf.opts.execution_message.message
 	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
-	if cnf.opts.execution_message.cleaning_interval > 0 then
-		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
-			cmd([[echon '']])
-		end)
-	end
-	api.nvim_echo({
-		{
-			(
-				type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
-				or cnf.opts.execution_message.message
-			),
-			AUTO_SAVE_COLOR,
-		},
-	}, true, {})
 	if cnf.opts.execution_message.cleaning_interval > 0 then
 		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
 			cmd([[echon '']])

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -53,6 +53,17 @@ local function debounce(lfn, duration)
 	return inner_debounce
 end
 
+local function echo_execution_message()
+	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
+		or cnf.opts.execution_message.message
+	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
+	if cnf.opts.execution_message.cleaning_interval > 0 then
+		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
+			cmd([[echon '']])
+		end)
+	end
+end
+
 function M.save(buf)
 	buf = buf or api.nvim_get_current_buf()
 
@@ -84,17 +95,6 @@ function M.save(buf)
 
 	if cnf.opts.execution_message.enabled == true then
 		echo_execution_message()
-	end
-end
-
-local function echo_execution_message()
-	local msg = type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message()
-		or cnf.opts.execution_message.message
-	api.nvim_echo({ { msg, AUTO_SAVE_COLOR } }, true, {})
-	if cnf.opts.execution_message.cleaning_interval > 0 then
-		fn.timer_start(cnf.opts.execution_message.cleaning_interval, function()
-			cmd([[echon '']])
-		end)
 	end
 end
 

--- a/lua/auto-save/types.lua
+++ b/lua/auto-save/types.lua
@@ -1,0 +1,4 @@
+--- @meta
+
+--- @alias VerboseTriggerEvent { [1]: string, pattern?: string }
+--- @alias TriggerEvent string | VerboseTriggerEvent

--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+local api = vim.api
+local augroup_name = "AutoSave"
+
+--- @param opts? table
+M.create_augroup = function(opts)
+  opts = opts or {}
+  api.nvim_create_augroup(augroup_name, opts)
+end
+
+--- @param pattern string
+--- @param saved_buffer number
+M.exec_autocmd = function(pattern, saved_buffer)
+  api.nvim_exec_autocmds("User", { pattern = pattern, data = { saved_buffer = saved_buffer } })
+end
+
+return M

--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -4,9 +4,10 @@ local api = vim.api
 local augroup_name = "AutoSave"
 
 --- @param opts? table
+--- @return number
 M.create_augroup = function(opts)
-  opts = opts or {}
-  api.nvim_create_augroup(augroup_name, opts)
+  opts = opts or { clear = true }
+  return api.nvim_create_augroup(augroup_name, opts)
 end
 
 --- @param pattern string

--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -3,6 +3,15 @@ local M = {}
 local api = vim.api
 local augroup_name = "AutoSave"
 
+--- @param event TriggerEvent
+--- @return VerboseTriggerEvent
+local function parse_trigger_event(event)
+  if type(event) == "string" then
+    return { event }
+  end
+  return event
+end
+
 --- @param opts? table
 --- @return number
 M.create_augroup = function(opts)
@@ -14,6 +23,17 @@ end
 --- @param saved_buffer number
 M.exec_autocmd = function(pattern, saved_buffer)
   api.nvim_exec_autocmds("User", { pattern = pattern, data = { saved_buffer = saved_buffer } })
+end
+
+--- @param trigger_events TriggerEvent[]?
+M.create_autocmd_for_trigger_events = function(trigger_events, autocmd_opts)
+  if trigger_events ~= nil then
+    for _, event in pairs(trigger_events) do
+      local parsed_event = parse_trigger_event(event)
+      local autocmd_opts_with_pattern = vim.tbl_extend("force", autocmd_opts, { pattern = parsed_event.pattern })
+      api.nvim_create_autocmd(parsed_event[1], autocmd_opts_with_pattern)
+    end
+  end
 end
 
 return M

--- a/lua/auto-save/utils/autocommands.lua
+++ b/lua/auto-save/utils/autocommands.lua
@@ -20,9 +20,13 @@ M.create_augroup = function(opts)
 end
 
 --- @param pattern string
---- @param saved_buffer number
-M.exec_autocmd = function(pattern, saved_buffer)
-  api.nvim_exec_autocmds("User", { pattern = pattern, data = { saved_buffer = saved_buffer } })
+--- @param data? table
+M.exec_autocmd = function(pattern, data)
+  local opts = { pattern = pattern }
+  if data ~= nil then
+    opts.data = data
+  end
+  api.nvim_exec_autocmds("User", opts)
 end
 
 --- @param trigger_events TriggerEvent[]?

--- a/lua/auto-save/utils/colors.lua
+++ b/lua/auto-save/utils/colors.lua
@@ -1,70 +1,70 @@
 local M = {}
 ---@param hex_str string hexadecimal value of a color
 local hex_to_rgb = function(hex_str)
-	local hex = "[abcdef0-9][abcdef0-9]"
-	local pat = "^#(" .. hex .. ")(" .. hex .. ")(" .. hex .. ")$"
-	hex_str = string.lower(hex_str)
+  local hex = "[abcdef0-9][abcdef0-9]"
+  local pat = "^#(" .. hex .. ")(" .. hex .. ")(" .. hex .. ")$"
+  hex_str = string.lower(hex_str)
 
-	assert(string.find(hex_str, pat) ~= nil, "hex_to_rgb: invalid hex_str: " .. tostring(hex_str))
+  assert(string.find(hex_str, pat) ~= nil, "hex_to_rgb: invalid hex_str: " .. tostring(hex_str))
 
-	local red, green, blue = string.match(hex_str, pat)
-	return { tonumber(red, 16), tonumber(green, 16), tonumber(blue, 16) }
+  local red, green, blue = string.match(hex_str, pat)
+  return { tonumber(red, 16), tonumber(green, 16), tonumber(blue, 16) }
 end
 
 function M.highlight(group, color, force)
-	if color.link then
-		vim.api.nvim_set_hl(0, group, {
-			link = color.link,
-		})
-	else
-		if color.style then
-			for _, style in ipairs(color.style) do
-				color[style] = true
-			end
-		end
-		color.style = nil
-		if force then
-			vim.cmd("hi " .. group .. " guifg=" .. (color.fg or "NONE") .. " guibg=" .. (color.bg or "NONE"))
-			return
-		end
-		vim.api.nvim_set_hl(0, group, color)
-	end
+  if color.link then
+    vim.api.nvim_set_hl(0, group, {
+      link = color.link,
+    })
+  else
+    if color.style then
+      for _, style in ipairs(color.style) do
+        color[style] = true
+      end
+    end
+    color.style = nil
+    if force then
+      vim.cmd("hi " .. group .. " guifg=" .. (color.fg or "NONE") .. " guibg=" .. (color.bg or "NONE"))
+      return
+    end
+    vim.api.nvim_set_hl(0, group, color)
+  end
 end
 
 function M.get_hl(name)
-	local ok, hl = pcall(vim.api.nvim_get_hl_by_name, name, true)
-	if not ok then
-		return
-	end
-	for _, key in pairs({ "foreground", "background", "special" }) do
-		if hl[key] then
-			hl[key] = string.format("#%06x", hl[key])
-		end
-	end
-	return hl
+  local ok, hl = pcall(vim.api.nvim_get_hl_by_name, name, true)
+  if not ok then
+    return
+  end
+  for _, key in pairs({ "foreground", "background", "special" }) do
+    if hl[key] then
+      hl[key] = string.format("#%06x", hl[key])
+    end
+  end
+  return hl
 end
 
 ---@param fg string forecrust color
 ---@param bg string background color
 ---@param alpha number number between 0 and 1. 0 results in bg, 1 results in fg
 function M.blend(fg, bg, alpha)
-	bg = hex_to_rgb(bg)
-	fg = hex_to_rgb(fg)
+  bg = hex_to_rgb(bg)
+  fg = hex_to_rgb(fg)
 
-	local blendChannel = function(i)
-		local ret = (alpha * fg[i] + ((1 - alpha) * bg[i]))
-		return math.floor(math.min(math.max(0, ret), 255) + 0.5)
-	end
+  local blendChannel = function(i)
+    local ret = (alpha * fg[i] + ((1 - alpha) * bg[i]))
+    return math.floor(math.min(math.max(0, ret), 255) + 0.5)
+  end
 
-	return string.format("#%02X%02X%02X", blendChannel(1), blendChannel(2), blendChannel(3))
+  return string.format("#%02X%02X%02X", blendChannel(1), blendChannel(2), blendChannel(3))
 end
 
 function M.darken(hex, amount, bg)
-	return M.blend(hex, bg or M.bg, math.abs(amount))
+  return M.blend(hex, bg or M.bg, math.abs(amount))
 end
 
 function M.lighten(hex, amount, fg)
-	return M.blend(hex, fg or M.fg, math.abs(amount))
+  return M.blend(hex, fg or M.fg, math.abs(amount))
 end
 
 return M

--- a/lua/auto-save/utils/data.lua
+++ b/lua/auto-save/utils/data.lua
@@ -14,12 +14,4 @@ function M.not_in(var, arr)
   end
 end
 
-function M.do_callback(callback_name)
-  local cnf = require("auto-save.config").opts
-
-  if type(cnf.callbacks[callback_name]) == "function" then
-    cnf.callbacks[callback_name]()
-  end
-end
-
 return M

--- a/lua/auto-save/utils/data.lua
+++ b/lua/auto-save/utils/data.lua
@@ -1,25 +1,25 @@
 local M = {}
 
 function M.set_of(list)
-	local set = {}
-	for i = 1, #list do
-		set[list[i]] = true
-	end
-	return set
+  local set = {}
+  for i = 1, #list do
+    set[list[i]] = true
+  end
+  return set
 end
 
 function M.not_in(var, arr)
-	if M.set_of(arr)[var] == nil then
-		return true
-	end
+  if M.set_of(arr)[var] == nil then
+    return true
+  end
 end
 
 function M.do_callback(callback_name)
-	local cnf = require("auto-save.config").opts
+  local cnf = require("auto-save.config").opts
 
-	if type(cnf.callbacks[callback_name]) == "function" then
-		cnf.callbacks[callback_name]()
-	end
+  if type(cnf.callbacks[callback_name]) == "function" then
+    cnf.callbacks[callback_name]()
+  end
 end
 
 return M

--- a/lua/auto-save/utils/data.lua
+++ b/lua/auto-save/utils/data.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local cnf = require("auto-save.config").opts
-
 function M.set_of(list)
 	local set = {}
 	for i = 1, #list do
@@ -17,6 +15,8 @@ function M.not_in(var, arr)
 end
 
 function M.do_callback(callback_name)
+	local cnf = require("auto-save.config").opts
+
 	if type(cnf.callbacks[callback_name]) == "function" then
 		cnf.callbacks[callback_name]()
 	end

--- a/lua/auto-save/utils/echo.lua
+++ b/lua/auto-save/utils/echo.lua
@@ -1,25 +1,25 @@
 local TITLE = "auto-save"
 
 return function(msg, kind)
-	local has_notify_plugin = pcall(require, "notify")
-	local level = {}
+  local has_notify_plugin = pcall(require, "notify")
+  local level = {}
 
-	if kind == "error" then
-		level.log = vim.log.levels.ERROR
-		level.type = "error"
-	elseif kind == "warn" then
-		level.log = vim.log.levels.WARN
-		level.type = "error"
-	else
-		level.log = kind or vim.log.levels.INFO
-		level.type = "info"
-	end
+  if kind == "error" then
+    level.log = vim.log.levels.ERROR
+    level.type = "error"
+  elseif kind == "warn" then
+    level.log = vim.log.levels.WARN
+    level.type = "error"
+  else
+    level.log = kind or vim.log.levels.INFO
+    level.type = "info"
+  end
 
-	if has_notify_plugin then
-		vim.notify(msg, level.log, {
-			title = TITLE,
-		})
-	else
-		vim.notify(("%s: %s"):format(TITLE, msg), level.log)
-	end
+  if has_notify_plugin then
+    vim.notify(msg, level.log, {
+      title = TITLE,
+    })
+  else
+    vim.notify(("%s: %s"):format(TITLE, msg), level.log)
+  end
 end

--- a/lua/auto-save/utils/logging.lua
+++ b/lua/auto-save/utils/logging.lua
@@ -1,0 +1,42 @@
+-- inspired from https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/log.lua
+
+local M = {}
+
+local outfile = string.format("%s/auto-save.log", vim.api.nvim_call_function("stdpath", { "cache" }))
+
+-- it could be that the directory of the file does not exist
+-- this would require further checks, see https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/log.lua#L138
+--- @param message string
+local write_to_outfile = function(message)
+  local f = assert(io.open(outfile, "a"))
+  f:write(message)
+  f:close()
+end
+
+M.new = function(options)
+  local enabled = options.debug
+
+  --- @param buf number | nil
+  --- @param message string
+  local log = function(buf, message)
+    if not enabled then
+      return
+    end
+
+    local log_message
+    if buf ~= nil then
+      local filename = vim.api.nvim_buf_get_name(buf)
+      log_message = string.format("[%s] [%s] - %s\n", os.date(), filename, message)
+    else
+      log_message = string.format("[%s] - %s\n", os.date(), message)
+    end
+
+    write_to_outfile(log_message)
+  end
+
+  return {
+    log = log,
+  }
+end
+
+return M

--- a/plugin/auto-save.lua
+++ b/plugin/auto-save.lua
@@ -1,15 +1,5 @@
-if vim.g.loaded_auto_save then
-  return
-end
-vim.g.loaded_auto_save = true
-
 local command = vim.api.nvim_create_user_command
-local cnf = require("auto-save.config").opts
 
 command("ASToggle", function()
   require("auto-save").toggle()
 end, {})
-
-if cnf.enabled then
-  require("auto-save").on()
-end

--- a/plugin/auto-save.lua
+++ b/plugin/auto-save.lua
@@ -1,5 +1,5 @@
 if vim.g.loaded_auto_save then
-	return
+  return
 end
 vim.g.loaded_auto_save = true
 
@@ -7,9 +7,9 @@ local command = vim.api.nvim_create_user_command
 local cnf = require("auto-save.config").opts
 
 command("ASToggle", function()
-	require("auto-save").toggle()
+  require("auto-save").toggle()
 end, {})
 
 if cnf.enabled then
-	require("auto-save").on()
+  require("auto-save").on()
 end

--- a/plugin/auto-save.lua
+++ b/plugin/auto-save.lua
@@ -1,5 +1,5 @@
 if vim.g.loaded_auto_save then
-  return
+	return
 end
 vim.g.loaded_auto_save = true
 

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,5 +1,10 @@
+column_width = 120
 line_endings = "Unix"
-indent_type = "Tabs"
-indent_width = 4
+indent_type = "Spaces"
+indent_width = 2
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,5 @@
+line_endings = "Unix"
+indent_type = "Tabs"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"


### PR DESCRIPTION
- style: add and apply stylua config
- Fix `debounce_delay` option not being read
- feat: allow to disable execution_message
- style: apply stylua
- refactor: define echo_execution_message before using
- fix: callbacks
- docs: drop breaking change notification
- docs: point links to this repo
- docs: add contributing section to readme
- docs: add installation instructions for lazy.nvim
- style: update stylua.toml and .editorconfig
- style: autoformat all the things
- feat: add defer_save, cancel_save, immediate_save trigger options (#11)
- docs: add note about conventional commits to readme (#14)
- refactor!: Assert `condition` before setting timers (#16)
- feature: Add logger for debugging (#18)
- ci: add stylua GitHub action (#20)
- ci: add pr lint workflow (#21)
- ci: fix stylua workflow (#22)
- ci: add vimdoc auto-generation workflow (#23)
- ci: fix panvimdoc version pinning (#24)
- chore(doc): auto-generate vimdoc
- feat!: Replace callbacks with autocommand events (#25)
- chore(doc): auto-generate vimdoc
- fix: disabling autosave wouldn't work (#28)
- chore(doc): auto-generate vimdoc
- fix: dim would not get applied when lazy loading plugin (#27)
- chore(doc): auto-generate vimdoc
- feat: [#15] Implement config option for `noautocmd` (#31)
- fix: [#30] Don't turn autosave on before reading user config (#32)
- chore(doc): auto-generate vimdoc
- fix: Empty `trigger_events` crash the plugin (#33)
- fix(readme): add missing end-of-line comma in Lazy.nvim installation configuration (#34)
- chore(doc): auto-generate vimdoc
- chore(doc): switch Events / Callbacks emoji (#35)
- chore(doc): auto-generate vimdoc
- feat: GH-40 Add `pattern` to `trigger_events` (#42)
- chore(doc): auto-generate vimdoc
- feat: GH-45 Add events when enabling/disabling the plugin
