### PR TITLE
Fix issue of auto save and auto format conflicting.

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -18,7 +18,15 @@ api.nvim_create_augroup("AutoSave", {
     clear = true,
 })
 
+
 local global_vars = {}
+local last_undo_seq = vim.fn.getreginfo('"').undo_seq
+
+local function check_lest_command_undo()
+    local current_undo_seq = vim.fn.getreginfo('"').undo_seq
+    last_undo_seq = current_undo_seq
+    return (current_undo_seq ~= last_undo_seq)
+end
 
 local function set_buf_var(buf, name, value)
     if buf == nil then
@@ -54,6 +62,11 @@ local function debounce(lfn, duration)
 end
 
 function M.save(buf)
+    if check_lest_command_undo() then
+        api.nvim.echo("Autosave skipped")
+        return
+    end
+
     buf = buf or api.nvim_get_current_buf()
 
     callback("before_asserting_save")
@@ -197,3 +210,4 @@ function M.setup(custom_opts)
 end
 
 return M
+

--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -22,7 +22,7 @@ api.nvim_create_augroup("AutoSave", {
 local global_vars = {}
 local last_undo_seq = vim.fn.getreginfo('"').undo_seq
 
-local function check_lest_command_undo()
+local function check_last_command_undo()
     local current_undo_seq = vim.fn.getreginfo('"').undo_seq
     last_undo_seq = current_undo_seq
     return (current_undo_seq ~= last_undo_seq)
@@ -62,7 +62,7 @@ local function debounce(lfn, duration)
 end
 
 function M.save(buf)
-    if check_lest_command_undo() then
+    if check_last_command_undo() then
         api.nvim.echo("Autosave skipped")
         return
     end


### PR DESCRIPTION
When auto save and auto format is turned on together, undo and redo does not work as expected because of a circular relationship. Consider this situation:

1. A change is made
2. Auto save saves this change
3. Auto format formats the changed buffer
4. Auto save saves this formatting

When you try to undo, you will undo the formatting after which auto save will save this undoing. This creates a circular relationship between auto save and auto format causing issues.

Fix this issue by not auto saving on an undo.